### PR TITLE
Polish files app UI integration

### DIFF
--- a/css/files_lock.css
+++ b/css/files_lock.css
@@ -1,0 +1,12 @@
+tr[data-locked='true'] .fileactions .action.action-menu.permanent {
+	position: relative;
+	top: 7px;
+}
+.locking-inline-state.icon-password {
+	padding: 17px 23px;
+	margin-right: -45px;
+	top: -5px;
+	width: 44px;
+	position: relative;
+	opacity: 0.5;
+}

--- a/js/files.js
+++ b/js/files.js
@@ -47,9 +47,9 @@
 					}
 					return t('files_lock', 'Lock file')
 				},
-				mime: 'all',
+				mime: 'file',
 				order: -140,
-				iconClass: 'icon-security',
+				iconClass: 'icon-password',
 				permissions: OC.PERMISSION_UPDATE,
 				actionHandler: self.switchLock
 			})
@@ -61,12 +61,13 @@
 					var locked = context.$file.data('locked')
 					var $actionLink = $('<span/>')
 					if (locked) {
-						$actionLink.text('Locked')
+						$actionLink.addClass('locking-inline-state')
+						$actionLink.addClass('icon-password')
 					}
 					context.$file.find('a.name>span.fileactions').append($actionLink)
 					return $actionLink
 				},
-				mime: 'all',
+				mime: 'file',
 				order: -140,
 				type: OCA.Files.FileActions.TYPE_INLINE,
 				permissions: OC.PERMISSION_UPDATE,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -88,6 +88,7 @@ class Application extends App {
 			'OCA\Files::loadAdditionalScripts',
 			function () {
 				Util::addScript(self::APP_NAME, 'files');
+				Util::addStyle(self::APP_NAME, 'files_lock');
 			}
 		);
 


### PR DESCRIPTION
Implements currently possible parts of https://github.com/nextcloud/files_lock/issues/3

- Add locked icon above 3-dots menu (while it is actually a bit a hacky apporach, it works quite well)
- Use proper icon
- Limit locking state to files

![image](https://user-images.githubusercontent.com/3404133/69657023-e35f9200-1079-11ea-9544-a0c95163c3cc.png)
![image](https://user-images.githubusercontent.com/3404133/69657046-ece8fa00-1079-11ea-9f46-d1dd8d3ab161.png)
![image](https://user-images.githubusercontent.com/3404133/69657075-f70af880-1079-11ea-9f2c-83feaf89d055.png)
![image](https://user-images.githubusercontent.com/3404133/69657119-0722d800-107a-11ea-9205-b0c92854ff6a.png)


