### PR TITLE
Make the displayname sortable

### DIFF
--- a/js/files.js
+++ b/js/files.js
@@ -72,9 +72,10 @@
 							return t('files_lock', 'Locked by {0}', [ context.$file.data('lockOwnerDisplayname') ])
 						}
 					}
+					return '';
 				},
 				mime: 'file',
-				order: -140,
+				order: -141,
 				iconClass: '',
 				icon: function(fileName, context) {
 					var lockOwner = context.$file.data('lockOwner')


### PR DESCRIPTION
Otherwise it is not possible to open the menu when the file is not locked. One of the two changes would be fine, but we save one sorting call if the order is already set differently.

Found by @rullzer 