### PR TITLE
Allow infinite lock through configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ By default, files locked using this app will be unlocked after 30 minutes.
 
 ### Settings
 
-Administrators can change the time of the maximum lock time (30) using the command:
+Administrators can change the time of the maximum lock time in minutes (30) using the command:
 
 `./occ config:app:set --value '30' files_lock lock_timeout`
 
+Locks have no expiry by default.
 
 
 ### More commands

--- a/lib/Command/Lock.php
+++ b/lib/Command/Lock.php
@@ -38,6 +38,7 @@ use OCA\FilesLock\Exceptions\LockNotFoundException;
 use OCA\FilesLock\Exceptions\NotFileException;
 use OCA\FilesLock\Exceptions\SuccessException;
 use OCA\FilesLock\Exceptions\UnauthorizedUnlockException;
+use OCA\FilesLock\Model\FileLock;
 use OCA\FilesLock\Service\ConfigService;
 use OCA\FilesLock\Service\FileService;
 use OCA\FilesLock\Service\LockService;
@@ -122,7 +123,7 @@ class Lock extends Base {
 	 * @throws NotFileException
 	 * @throws InvalidPathException
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$fileId = (int)$input->getArgument('file_id');
 		$userId = $input->getArgument('user_id');
 
@@ -136,7 +137,7 @@ class Lock extends Base {
 			$this->getStatus($input, $output, $fileId);
 			$this->unlockFile($input, $output, $fileId);
 		} catch (SuccessException $e) {
-			return;
+			return 0;
 		}
 
 		if ($userId === '') {
@@ -144,6 +145,8 @@ class Lock extends Base {
 		}
 
 		$this->lockFile($input, $output, $fileId, $userId);
+
+		return 0;
 	}
 
 
@@ -164,6 +167,14 @@ class Lock extends Base {
 			$output->writeln(
 				'File #' . $fileId . ' is <comment>locked</comment> by ' . $lock->getUserId()
 			);
+			$output->writeln(
+				' - Locked at: ' . date('c', $lock->getCreation())
+			);
+			if ($lock->getETA() !== FileLock::ETA_INFINITE) {
+				$output->writeln(
+					' - Expiry in seconds: ' . $lock->getETA()
+				);
+			}
 		} catch (LockNotFoundException $e) {
 			$output->writeln('File #' . $fileId . ' is <info>not locked<info>');
 		}

--- a/lib/Model/FileLock.php
+++ b/lib/Model/FileLock.php
@@ -45,6 +45,8 @@ class FileLock implements IQueryRow, JsonSerializable {
 
 	use TArrayTools;
 
+	public const ETA_INFINITE = -1;
+
 
 	/** @var int */
 	private $id = 0;
@@ -196,6 +198,9 @@ class FileLock implements IQueryRow, JsonSerializable {
 	 * @return int
 	 */
 	public function getETA(): int {
+		if ($this->getTimeout() <= 0) {
+			return self::ETA_INFINITE;
+		}
 		$end = $this->getCreation() + $this->getTimeout();
 		$eta = $end - time();
 

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -41,7 +41,7 @@ class ConfigService {
 	const LOCK_TIMEOUT = 'lock_timeout';
 
 	public $defaults = [
-		self::LOCK_TIMEOUT => '30'
+		self::LOCK_TIMEOUT => '0'
 	];
 
 	/** @var string */


### PR DESCRIPTION
Implements https://github.com/nextcloud/files_lock/issues/49

- Allow setting lock_timeout to 0 for not-expiring locks
- Print out expiry details in the occ status command
- Make no expiry the default