### PR TITLE
Fix type of param for creation column

### DIFF
--- a/lib/Db/LocksRequest.php
+++ b/lib/Db/LocksRequest.php
@@ -35,6 +35,7 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Exception;
 use OCA\FilesLock\Exceptions\LockNotFoundException;
 use OCA\FilesLock\Model\FileLock;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 /**
  * Class LocksRequest
@@ -140,14 +141,14 @@ class LocksRequest extends LocksRequestBuilder {
 
 
 	/**
-	 * @param int $timeout
+	 * @param int $timeout in minutes
 	 *
 	 * @return FileLock[]
 	 * @throws Exception
 	 */
 	public function getLocksOlderThan(int $timeout): array {
 		$qb = $this->getLocksSelectSql();
-		$qb->limitToCreation($timeout);
+		$qb->andWhere($qb->expr()->lt('l.creation', $qb->createNamedParameter($timeout * 60, IQueryBuilder::PARAM_INT)));
 
 		return $this->getLocksFromRequest($qb);
 	}

--- a/lib/Tools/Db/ExtendedQueryBuilder.php
+++ b/lib/Tools/Db/ExtendedQueryBuilder.php
@@ -195,7 +195,7 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		$orX = $expr->orX();
 		$orX->add(
-			$expr->lte($field, $this->createNamedParameter($date, IQueryBuilder::PARAM_DATE))
+			$expr->lte($field, $this->createNamedParameter($date, IQueryBuilder::PARAM_INT))
 		);
 
 		if ($orNull === true) {

--- a/lib/Tools/Db/ExtendedQueryBuilder.php
+++ b/lib/Tools/Db/ExtendedQueryBuilder.php
@@ -31,7 +31,6 @@ declare(strict_types=1);
 
 namespace OCA\FilesLock\Tools\Db;
 
-use DateInterval;
 use DateTime;
 use Doctrine\DBAL\Query\QueryBuilder as DBALQueryBuilder;
 use Exception;
@@ -163,48 +162,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	public function limitToMemberId(string $memberId): void {
 		$this->limit('member_id', $memberId);
 	}
-
-	/**
-	 * Limit the request to the creation
-	 *
-	 * @param int $delay
-	 *
-	 * @return self
-	 * @throws Exception
-	 */
-	public function limitToCreation(int $delay = 0): self {
-		$date = new DateTime('now');
-		$date->sub(new DateInterval('PT' . $delay . 'M'));
-
-		$this->limitToDBFieldDateTime('creation', $date, true);
-
-		return $this;
-	}
-
-
-	/**
-	 * @param string $field
-	 * @param DateTime $date
-	 * @param bool $orNull
-	 */
-	public function limitToDBFieldDateTime(string $field, DateTime $date, bool $orNull = false): void {
-		$expr = $this->expr();
-		$pf = ($this->getType() === DBALQueryBuilder::SELECT) ? $this->getDefaultSelectAlias()
-																. '.' : '';
-		$field = $pf . $field;
-
-		$orX = $expr->orX();
-		$orX->add(
-			$expr->lte($field, $this->createNamedParameter($date, IQueryBuilder::PARAM_INT))
-		);
-
-		if ($orNull === true) {
-			$orX->add($expr->isNull($field));
-		}
-
-		$this->andWhere($orX);
-	}
-
 
 	/**
 	 * @param int $timestamp

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -41,7 +41,9 @@
     </MissingDependency>
   </file>
   <file src="lib/Db/LocksRequest.php">
-    <MissingDependency occurrences="25">
+    <MissingDependency occurrences="27">
+      <code>$qb</code>
+      <code>$qb</code>
       <code>$qb</code>
       <code>$qb</code>
       <code>$qb</code>


### PR DESCRIPTION
It's actually an int, not a date type.

This is the only use of `limitToDBFieldDateTime` so I change it directly in the function, but could be troublesome later.

Closes https://github.com/nextcloud/files_lock/issues/15#issuecomment-631456327