### PR TITLE
fix: Avoid getting the user folder for non-files dav paths

### DIFF
--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -31,9 +31,11 @@ declare(strict_types=1);
 
 namespace OCA\FilesLock\Service;
 
+use OC\User\NoUserException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 
@@ -124,9 +126,14 @@ class FileService {
 	 *
 	 * @return Node
 	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 * @throws NoUserException
 	 */
 	public function getFileFromAbsoluteUri(string $uri): Node {
-		list(, $userId, $path) = explode('/', trim($uri, '/') . '/', 3);
+		list($root, $userId, $path) = explode('/', trim($uri, '/') . '/', 3);
+		if ($root !== 'files') {
+			throw new NotFoundException();
+		}
 		$path = '/' . $path;
 		$file = $this->rootFolder->getUserFolder($userId)
 								 ->get($path);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/files_lock/issues/69

There are no locks for other dav endpoints and this will avoid log spam like:

```
[files] Error: OC\User\NoUserException: Backends provided no user object at <<closure>>

 0. <<closure>>
    OC\Files\Node\Root->getUserFolder("deckCard")
 1. /var/www/cloud.nextcloud.com/nextcloud/lib/private/Files/Node/LazyFolder.php line 72
    call_user_func_array([["OC\\Files\\No ... "], ["deckCard"])
 2. /var/www/cloud.nextcloud.com/nextcloud/lib/private/Files/Node/LazyRoot.php line 40
    OC\Files\Node\LazyFolder->__call("getUserFolder", ["deckCard"])
 3. /var/www/cloud.nextcloud.com/nextcloud/apps/files_lock/lib/Service/FileService.php line 131
    OC\Files\Node\LazyRoot->getUserFolder("deckCard")
 4. /var/www/cloud.nextcloud.com/nextcloud/apps/files_lock/lib/DAV/LockBackend.php line 148
    OCA\FilesLock\Service\FileService->getFileFromAbsoluteUri("comments/deckCard/5523")
 5. /var/www/cloud.nextcloud.com/nextcloud/apps/files_lock/lib/DAV/LockBackend.php line 74
    OCA\FilesLock\DAV\LockBackend->getFileFromUri("comments/deckCard/5523")
 6. /var/www/cloud.nextcloud.com/nextcloud/3rdparty/sabre/dav/lib/DAV/Locks/Plugin.php line 141
    OCA\FilesLock\DAV\LockBackend->getLocks("comments/deckCard/5523", false)
 7. /var/www/cloud.nextcloud.com/nextcloud/3rdparty/sabre/dav/lib/DAV/Locks/Plugin.php line 415
    Sabre\DAV\Locks\Plugin->getLocks("comments/deckCard/5523", false)
 8. /var/www/cloud.nextcloud.com/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php line 89
    Sabre\DAV\Locks\Plugin->validateTokens("*** sensitive parameters replaced ***")
 9. /var/www/cloud.nextcloud.com/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php line 1448
    Sabre\DAV\Server->emit("validateTokens", ["*** sensitive  ... "])
10. /var/www/cloud.nextcloud.com/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php line 466
    Sabre\DAV\Server->checkPreconditions("*** sensitive parameters replaced ***", ["Sabre\\HTTP\\Response"])
11. /var/www/cloud.nextcloud.com/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php line 253
    Sabre\DAV\Server->invokeMethod("*** sensitive parameters replaced ***", ["Sabre\\HTTP\\Response"])
12. /var/www/cloud.nextcloud.com/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php line 321
    Sabre\DAV\Server->start()
13. /var/www/cloud.nextcloud.com/nextcloud/apps/dav/lib/Server.php line 363
    Sabre\DAV\Server->exec()
14. /var/www/cloud.nextcloud.com/nextcloud/apps/dav/appinfo/v2/remote.php line 35
    OCA\DAV\Server->exec()
15. /var/www/cloud.nextcloud.com/nextcloud/remote.php line 171
    require_once("/var/www/cloud. ... p")

PROPPATCH /remote.php/dav/comments/deckCard/5523
```