### PR TITLE
fix: Ingore error if unlocking an already unlocked file

### DIFF
--- a/js/files.js
+++ b/js/files.js
@@ -131,6 +131,11 @@
 				}).done(function(res) {
 					model.set('locked', false)
 				}).fail(function(res) {
+					if (res.status === 412) {
+						// No lock available so we assume unlocked
+						model.set('locked', false)
+						return;
+					}
 					OCP.Toast.warning(res.responseJSON.ocs.meta.message)
 				});
 			} else {


### PR DESCRIPTION

If a file has already been unlocked in the meantime, we can just move on.

Steps to reproduce:
- Lock a file manually
- Open the file list again in a second tab
- Unlock in tab 1
- Try to unlock in tab 2