### PR TITLE
fix: Allow the file owner to always unlock

### DIFF
--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -245,6 +245,10 @@ class LockService {
 			return;
 		}
 
+		if ($request->getType() === ILock::TYPE_USER && $request->getNode()->getOwner()->getUID() === $this->userId) {
+			return;
+		}
+
 		throw new UnauthorizedUnlockException(
 			$this->l10n->t('File can only be unlocked by the owner of the lock')
 		);


### PR DESCRIPTION
This is a first step towards https://github.com/nextcloud/files_lock/issues/52#issuecomment-1119535188 to allow the file owner to unlock it.
Fixes https://github.com/nextcloud/files_lock/issues/102

In shared ownership context like groupfolders/external storages this might mean that everyone can unlock, but seems more reasonable for now until we have a more sophisticated implementation with a dedicated role of a "lock admin" or make use of acls. This seems better than having possibe stale locks that only the admin can remove through occ