### PR TITLE
fix: Try only updating parent etags

### DIFF
--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -384,9 +384,6 @@ class LockService {
 
 	private function propagateEtag(LockContext $lockContext): void {
 		$node = $lockContext->getNode();
-		$node->getStorage()->getCache()->update($node->getId(), [
-			'etag' => uniqid(),
-		]);
 		$node->getStorage()->getUpdater()->propagate($node->getInternalPath(), $node->getMTime());
 	}
 }


### PR DESCRIPTION
This would be a PoC to not update the files etag itself, but just the parent folder ones when lock or unlock happens as per #147 

This should be sufficient for the clients to refetch the current lock state through prop finds.

@camilasan @mgallien This could help to avoid resync on the desktop client but would need some proper testing.

@mpivchev @tobiasKaminsky Also having some tests on the mobile apps would be great here.