### PR TITLE
fix: Do not load unused event dispatcher

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -119,8 +119,6 @@ class Application extends App implements IBootstrap {
 	 * @param IServerContainer $container
 	 */
 	public function registerHooks(IServerContainer $container) {
-		$eventDispatcher = \OC::$server->getEventDispatcher();
-
 		$this->userSession = $container->get(IUserSession::class);
 		$this->fileService = $container->get(FileService::class);
 		$this->lockService = $container->get(LockService::class);


### PR DESCRIPTION
It wasn't used and `getEventDispatcher` was dropped for 28