### PR TITLE
feat(dav): Expose etag property after user LOCK/UNLOCK

### DIFF
--- a/lib/Controller/LockController.php
+++ b/lib/Controller/LockController.php
@@ -130,7 +130,7 @@ class LockController extends OCSController {
 			$lock = $this->lockService->getLockFromFileId((int)$fileId);
 			$response = new DataResponse();
 			$response->setStatus(Http::STATUS_LOCKED);
-			$response->setData($lock);
+			$response->setData($lock->jsonSerialize());
 			return $response;
 		} catch (Exception $e) {
 			return $this->fail($e);

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,29 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="lib/DAV/LockBackend.php">
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;server</code>
+    <UndefinedThisPropertyAssignment>
+      <code><![CDATA[$this->server]]></code>
     </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;server</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="lib/DAV/LockPlugin.php">
-    <UndefinedClass occurrences="5">
+    <UndefinedClass>
       <code>CachingTree</code>
       <code>Directory</code>
       <code>FakeLockerPlugin</code>
       <code>File</code>
+      <code>FilesPlugin</code>
       <code>ObjectTree</code>
     </UndefinedClass>
   </file>
   <file src="lib/Db/CoreQueryBuilder.php">
-    <MissingDependency occurrences="1">
+    <MissingDependency>
       <code>ExtendedQueryBuilder</code>
     </MissingDependency>
   </file>
   <file src="lib/Db/CoreRequestBuilder.php">
-    <MissingDependency occurrences="9">
+    <MissingDependency>
       <code>$qb</code>
       <code>$qb</code>
       <code>$qb</code>
@@ -36,7 +34,7 @@
     </MissingDependency>
   </file>
   <file src="lib/Db/LocksRequest.php">
-    <MissingDependency occurrences="27">
+    <MissingDependency>
       <code>$qb</code>
       <code>$qb</code>
       <code>$qb</code>
@@ -65,12 +63,12 @@
       <code>$qb</code>
       <code>$qb</code>
     </MissingDependency>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>UniqueConstraintViolationException</code>
     </UndefinedClass>
   </file>
   <file src="lib/Db/LocksRequestBuilder.php">
-    <MissingDependency occurrences="6">
+    <MissingDependency>
       <code>CoreQueryBuilder</code>
       <code>CoreQueryBuilder</code>
       <code>CoreQueryBuilder</code>
@@ -80,22 +78,22 @@
     </MissingDependency>
   </file>
   <file src="lib/LockProvider.php">
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>$lock</code>
     </RedundantCondition>
   </file>
   <file src="lib/Service/FileService.php">
-    <MissingDependency occurrences="6">
-      <code>$this-&gt;rootFolder</code>
-      <code>$this-&gt;rootFolder</code>
-      <code>$this-&gt;rootFolder</code>
-      <code>$this-&gt;rootFolder</code>
+    <MissingDependency>
+      <code><![CDATA[$this->rootFolder]]></code>
+      <code><![CDATA[$this->rootFolder]]></code>
+      <code><![CDATA[$this->rootFolder]]></code>
+      <code><![CDATA[$this->rootFolder]]></code>
       <code>IRootFolder</code>
       <code>IRootFolder</code>
     </MissingDependency>
   </file>
   <file src="lib/Tools/Traits/TArrayTools.php">
-    <TypeDoesNotContainNull occurrences="7">
+    <TypeDoesNotContainNull>
       <code>$arr === null</code>
       <code>$arr === null</code>
       <code>$arr === null</code>
@@ -106,11 +104,11 @@
     </TypeDoesNotContainNull>
   </file>
   <file src="lib/Tools/Traits/TSetup.php">
-    <MismatchingDocblockParamType occurrences="2">
+    <MismatchingDocblockParamType>
       <code>string</code>
       <code>string</code>
     </MismatchingDocblockParamType>
-    <MismatchingDocblockReturnType occurrences="1">
+    <MismatchingDocblockReturnType>
       <code>string</code>
     </MismatchingDocblockReturnType>
   </file>


### PR DESCRIPTION
For #162 


Example response

```
<?xml version="1.0"?>
<d:prop
	xmlns:d="DAV:"
	xmlns:s="http://sabredav.org/ns"
	xmlns:oc="http://owncloud.org/ns"
	xmlns:nc="http://nextcloud.org/ns">
	<d:getetag>64f72cfda6dd4</d:getetag>
	<nc:lock>1</nc:lock>
	<nc:lock-owner-type>0</nc:lock-owner-type>
	<nc:lock-owner>admin</nc:lock-owner>
	<nc:lock-owner-displayname>admin</nc:lock-owner-displayname>
	<nc:lock-owner-editor>admin</nc:lock-owner-editor>
	<nc:lock-time>1693920509</nc:lock-time>
	<nc:lock-timeout>1</nc:lock-timeout>
	<nc:lock-token>files_lock/3d2b8817-7e39-465a-bfa0-033cb81b1da3</nc:lock-token>
</d:prop>

```
