### PR TITLE
with files client automated locking we need a sane default value

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -39,7 +39,7 @@ class ConfigService {
 	public const LOCK_TIMEOUT = 'lock_timeout';
 
 	public $defaults = [
-		self::LOCK_TIMEOUT => '0'
+		self::LOCK_TIMEOUT => '30'
 	];
 
 	/** @var string */


### PR DESCRIPTION
would prevent having locks with 0 tiemout because the config value is never changed on server

there will be more locks since desktop files client will automatically lock office files making this more visible