### PR TITLE
store display-name on insert

### DIFF
--- a/lib/Db/LocksRequest.php
+++ b/lib/Db/LocksRequest.php
@@ -51,6 +51,7 @@ class LocksRequest extends LocksRequestBuilder {
 		$qb->setValue('user_id', $qb->createNamedParameter($lock->getOwner()))
 		   ->setValue('file_id', $qb->createNamedParameter($lock->getFileId()))
 		   ->setValue('token', $qb->createNamedParameter($lock->getToken()))
+		   ->setValue('owner', $qb->createNamedParameter($lock->getDisplayName()))
 		   ->setValue('creation', $qb->createNamedParameter($lock->getCreatedAt()))
 		   ->setValue('type', $qb->createNamedParameter($lock->getType()))
 		   ->setValue('ttl', $qb->createNamedParameter($lock->getTimeout()));


### PR DESCRIPTION
this is missing on `insert`, as it is already on `update`:

https://github.com/nextcloud/files_lock/blob/ded15ac46163ac0dba5a626ce66a753f3de1eb13/lib/Db/LocksRequest.php#L70-L73