### PR TITLE
Fix lock state icon position in detailed files' lists

### DIFF
--- a/css/files_lock.css
+++ b/css/files_lock.css
@@ -4,7 +4,7 @@ tr[data-locked='true'] .fileactions .action.action-menu.permanent {
 }
 .locking-inline-state.icon-password {
 	padding: 17px 23px;
-	margin-right: -45px;
+	margin-right: -49px;
 	top: -5px;
 	width: 44px;
 	position: relative;

--- a/css/files_lock.css
+++ b/css/files_lock.css
@@ -4,10 +4,10 @@ tr[data-locked='true'] .fileactions .action.action-menu.permanent {
 }
 .locking-inline-state.icon-password {
 	padding: 17px 23px;
-	margin-right: -49px;
-	top: -5px;
+	right: -1px;
+	top: 0px;
 	width: 44px;
-	position: relative;
+	position: absolute;
 	opacity: 0.5;
 }
 


### PR DESCRIPTION
**Before :** 
![Capture d’écran du 2023-10-11 15-38-40](https://github.com/nextcloud/files_lock/assets/33763786/4ac1b049-3a1b-447e-ab50-438fdffc87aa)
**After :**
![Capture d’écran du 2023-10-11 15-38-23](https://github.com/nextcloud/files_lock/assets/33763786/0084296a-a8ef-4ccb-b641-5ba7069460a8)
