### PR TITLE
feat: Add API parameters to specify the lock type

### DIFF
--- a/lib/Capability.php
+++ b/lib/Capability.php
@@ -9,6 +9,7 @@ class Capability implements ICapability {
 		return [
 			'files' => [
 				'locking' => '1.0',
+				'api-feature-lock-type' => true,
 			]
 		];
 	}

--- a/lib/Controller/LockController.php
+++ b/lib/Controller/LockController.php
@@ -90,13 +90,13 @@ class LockController extends OCSController {
 	 *
 	 * @return DataResponse
 	 */
-	public function locking(string $fileId): DataResponse {
+	public function locking(string $fileId, int $lockType = ILock::TYPE_USER): DataResponse {
 		try {
 			$user = $this->userSession->getUser();
 			$file = $this->fileService->getFileFromId($user->getUID(), (int)$fileId);
 
 			$lock = $this->lockService->lock(new LockContext(
-				$file, ILock::TYPE_USER, $user->getUID()
+				$file, $lockType, $user->getUID()
 			));
 
 			return new DataResponse($lock, Http::STATUS_OK);
@@ -115,7 +115,7 @@ class LockController extends OCSController {
 	 *
 	 * @return DataResponse
 	 */
-	public function unlocking(string $fileId): DataResponse {
+	public function unlocking(string $fileId, int $lockType = ILock::TYPE_USER): DataResponse {
 		try {
 			$user = $this->userSession->getUser();
 			$this->lockService->enableUserOverride();

--- a/lib/DAV/LockPlugin.php
+++ b/lib/DAV/LockPlugin.php
@@ -183,13 +183,14 @@ class LockPlugin extends SabreLockPlugin {
 
 	public function httpLock(RequestInterface $request, ResponseInterface $response) {
 		if ($request->getHeader('X-User-Lock')) {
+			$lockType = (int)($request->getHeader('X-User-Lock-Type') ?? ILock::TYPE_USER);
 			$response->setHeader('Content-Type', 'application/xml; charset=utf-8');
 
 			$file = $this->fileService->getFileFromAbsoluteUri($this->server->getRequestUri());
 
 			try {
 				$lockInfo = $this->lockService->lock(new LockContext(
-					$file, ILock::TYPE_USER, $this->userSession->getUser()->getUID()
+					$file, $lockType, $this->userSession->getUser()->getUID()
 				));
 				$response->setStatus(200);
 				$response->setBody(
@@ -216,6 +217,7 @@ class LockPlugin extends SabreLockPlugin {
 
 	public function httpUnlock(RequestInterface $request, ResponseInterface $response) {
 		if ($request->getHeader('X-User-Lock')) {
+			$lockType = (int)($request->getHeader('X-User-Lock-Type') ?? ILock::TYPE_USER);
 			$response->setHeader('Content-Type', 'application/xml; charset=utf-8');
 
 			$file = $this->fileService->getFileFromAbsoluteUri($this->server->getRequestUri());
@@ -223,7 +225,7 @@ class LockPlugin extends SabreLockPlugin {
 			try {
 				$this->lockService->enableUserOverride();
 				$this->lockService->unlock(new LockContext(
-					$file, ILock::TYPE_USER, $this->userSession->getUser()->getUID()
+					$file, $lockType, $this->userSession->getUser()->getUID()
 				));
 				$response->setStatus(200);
 				$response->setBody(


### PR DESCRIPTION
Allow setting other lock types through the WebDAV user lock and OCS API.

- [x] Double check if this covers the use case
- [x] Add capability to indicate support for the new API parameter
- [x] Write documentation

Used by https://github.com/nextcloud/desktop/pull/6347