### PR TITLE
[stable27] fix: Preserve lock data in file info model

### DIFF
--- a/js/files.js
+++ b/js/files.js
@@ -43,6 +43,18 @@
 				return data
 			})
 
+			var oldElementToFile = fileList.elementToFile
+			fileList.elementToFile = function($el) {
+				var fileData = oldElementToFile.apply(this, arguments)
+				fileData.locked = $el.data('locked')
+				fileData.lockOwnerType = $el.data('lock-owner-type')
+				fileData.lockOwnerEditor = $el.data('lock-owner-editor')
+				fileData.lockOwner = $el.data('lock-owner')
+				fileData.lockOwnerDisplayname = $el.data('lock-owner-displayname')
+				fileData.lockTime = $el.data('lock-time')
+				return fileData
+			}
+
 			var oldCreateRow = fileList._createRow
 			fileList._createRow = function(fileData) {
 				var $tr = oldCreateRow.apply(this, arguments)


### PR DESCRIPTION
When we obtain the model trough getModelForFile which reads the
properties from the table row element, which does not preserve already
fetched lock information otherwise.

This fixes disappearing lock information after leaving a document editor like Collabora where we update the file model based on the result of fileList.getModelForFile to indicate the last saved modification date update.

Note this is not a nice approach but the bug is solved by the clean API that the files app and files_lock use with 28 anyways.

Steps to reproduce:
- Lock a file manually
- Open the file with Collabora
- Do some changes and save
- Close the document

before:
- The file was no longer displayed as locked

After:
- The file is still displayed as locked