### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,12 +183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b6148b83b113b951fcbee80b00b2279b188c947b"
+                "reference": "ab6acaabffc6a58f2b703fc10f425ec7e99383ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b6148b83b113b951fcbee80b00b2279b188c947b",
-                "reference": "b6148b83b113b951fcbee80b00b2279b188c947b",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ab6acaabffc6a58f2b703fc10f425ec7e99383ce",
+                "reference": "ab6acaabffc6a58f2b703fc10f425ec7e99383ce",
                 "shasum": ""
             },
             "require": {
@@ -219,7 +219,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-01-16T00:34:24+00:00"
+            "time": "2024-02-04T00:34:59+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency