### PR TITLE
fix: Use lock owner display name on error response

### DIFF
--- a/lib/Controller/LockController.php
+++ b/lib/Controller/LockController.php
@@ -150,7 +150,7 @@ class LockController extends OCSController {
 		if ($data->getStatus() === Http::STATUS_LOCKED) {
 			/** @var FileLock $lock */
 			$lock = $data->getData();
-			$message = $this->l10n->t('File is currently locked by %s', [$lock->getOwner()]);
+			$message = $this->l10n->t('File is currently locked by %s', [$lock->getDisplayName()]);
 		}
 		if ($data->getStatus() === Http::STATUS_PRECONDITION_FAILED) {
 			/** @var FileLock $lock */


### PR DESCRIPTION
Fix https://github.com/nextcloud/files_lock/issues/250