### PR TITLE
fix: Allow to unlock based on the current lock not the requested one to allow lock owners to unlock in any case

### DIFF
--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -231,7 +231,7 @@ class LockService {
 		$isSameType = $request->getType() === $current->getType();
 
 		// Check the token for token based locks
-		if ($request->getType() === ILock::TYPE_TOKEN) {
+		if ($current->getType() === ILock::TYPE_TOKEN) {
 			if ($isSameToken || ($this->allowUserOverride && $isSameUser)) {
 				return;
 			}


### PR DESCRIPTION
Steps to reproduce:
- Share a folder from user A to user B
- As user B: 
  - Have a collabora file
  - Lock a file automatically by the client or lock it manually and fake the type to be 2 in the database
  - Try to unlock through the web UI