### PR TITLE
Return proper lock type in webdav response

### DIFF
--- a/lib/DAV/LockPlugin.php
+++ b/lib/DAV/LockPlugin.php
@@ -157,9 +157,7 @@ class LockPlugin extends SabreLockPlugin {
 				return null;
 			}
 
-			$type = $lock->getType();
-
-			return $type !== ILock::TYPE_TOKEN ? $type : ILock::TYPE_USER;
+			return $lock->getType();
 		});
 
 		$propFind->handle(Application::DAV_PROPERTY_LOCK_EDITOR, function () use ($nodeId) {


### PR DESCRIPTION
The desktop client expects the proper lock type so we should return it that way as well