### PR TITLE
fix/error display name

### DIFF
--- a/lib/Controller/LockController.php
+++ b/lib/Controller/LockController.php
@@ -150,6 +150,7 @@ class LockController extends OCSController {
 		if ($data->getStatus() === Http::STATUS_LOCKED) {
 			/** @var FileLock $lock */
 			$lock = $data->getData();
+			$this->lockService->injectMetadata($lock);
 			$message = $this->l10n->t('File is currently locked by %s', [$lock->getDisplayName()]);
 		}
 		if ($data->getStatus() === Http::STATUS_PRECONDITION_FAILED) {

--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -333,24 +333,13 @@ class LockService {
 	public function injectMetadata(FileLock $lock): FileLock {
 		$displayName = null;
 		if ($lock->getType() === ILock::TYPE_USER) {
-			if (!method_exists($this->userManager, 'getDisplayName')) {
-				// TODO: Remove once 25 is the minimum supported version
-				$displayName = $this->userManager->get($lock->getOwner())->getDisplayName();
-			} else {
-				$displayName = $this->userManager->getDisplayName($lock->getOwner());
-			}
+			$displayName = $this->userManager->getDisplayName($lock->getOwner());
 		}
 		if ($lock->getType() === ILock::TYPE_APP) {
 			$displayName = $this->getAppName($lock->getOwner()) ?? null;
 		}
 		if ($lock->getType() === ILock::TYPE_TOKEN) {
-			if (!method_exists($this->userManager, 'getDisplayName')) {
-				// TODO: Remove once 25 is the minimum supported version
-				$user = $this->userManager->get($lock->getOwner());
-				$displayName = $user ? $user->getDisplayName(): $lock->getDisplayName();
-			} else {
-				$displayName = $this->userManager->getDisplayName($lock->getOwner()) ?? $lock->getDisplayName();
-			}
+			$displayName = $this->userManager->getDisplayName($lock->getOwner()) ?? $lock->getDisplayName();
 		}
 
 		if ($displayName) {

--- a/lib/Tools/Db/ExtendedQueryBuilder.php
+++ b/lib/Tools/Db/ExtendedQueryBuilder.php
@@ -44,7 +44,6 @@ use OCA\FilesLock\Tools\Traits\TArrayTools;
 use OCP\DB\QueryBuilder\ICompositeExpression;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
-use OCP\ILogger;
 use Psr\Log\LoggerInterface;
 
 class ExtendedQueryBuilder extends QueryBuilder {
@@ -59,19 +58,11 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * ExtendedQueryBuilder constructor.
 	 */
 	public function __construct() {
-		if (\OCP\Util::getVersion()[0] >= 24) {
-			parent::__construct(
-				OC::$server->get(IDBConnection::class),
-				OC::$server->get(SystemConfig::class),
-				OC::$server->get(LoggerInterface::class)
-			);
-		} else {
-			parent::__construct(
-				OC::$server->get(IDBConnection::class),
-				OC::$server->get(SystemConfig::class),
-				OC::$server->get(ILogger::class)
-			);
-		}
+		parent::__construct(
+			OC::$server->get(IDBConnection::class),
+			OC::$server->get(SystemConfig::class),
+			OC::$server->get(LoggerInterface::class)
+		);
 	}
 
 


### PR DESCRIPTION
- **fix: Set displayname for error response**
- **chore: Remove compatibility check for display name**

We do not store the display name in the database as it might be used by native WebDAV locking for weird identifiers from the webdav clients. However with that we need to enhance the lock object with the actual display name before using it in an error response.