### PR TITLE
fix: Only update lock timeout when it is not infinite

### DIFF
--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -169,7 +169,7 @@ class LockService {
 				$known->getType() === $lockScope->getType() && ($known->getOwner() === $lockScope->getOwner() || $known->getToken() === $lockScope->getOwner())
 			) {
 				$known->setTimeout(
-					$known->getTimeout() - $known->getETA() + $this->configService->getTimeoutSeconds()
+					$known->getETA() !== FileLock::ETA_INFINITE ? $known->getTimeout() - $known->getETA() + $this->configService->getTimeoutSeconds() : 0
 				);
 				$this->notice('extending existing lock', false, ['fileLock' => $known]);
 				$this->locksRequest->update($known);


### PR DESCRIPTION
Otherwise if the desktop client tries to refresh an infinite lock it will auto expire on the next check as it will be set to 1 second (`0 - (-1) - 0`)