### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/lib/DAV/LockBackend.php
+++ b/lib/DAV/LockBackend.php
@@ -39,27 +39,14 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use Sabre\DAV\Locks\Backend\BackendInterface;
 use Sabre\DAV\Locks\LockInfo;
-use Sabre\DAV\Server;
 
 class LockBackend implements BackendInterface {
-	/** @var FileService */
-	private $fileService;
-
-	/** @var LockService */
-	private $lockService;
-
-	/** @var bool */
-	private $absolute = false;
-
 	public function __construct(
-		Server $server, FileService $fileService, LockService $lockService, bool $absolute
+		private FileService $fileService,
+		private LockService $lockService,
+		private bool $absolute
 	) {
-		$this->server = $server;
-		$this->fileService = $fileService;
-		$this->lockService = $lockService;
-		$this->absolute = $absolute;
 	}
-
 
 	/**
 	 * @param string $uri

--- a/lib/DAV/LockPlugin.php
+++ b/lib/DAV/LockPlugin.php
@@ -58,7 +58,7 @@ class LockPlugin extends SabreLockPlugin {
 				$absolute = true;
 				break;
 		}
-		$this->locksBackend = new LockBackend($server, $this->fileService, $this->lockService, $absolute);
+		$this->locksBackend = new LockBackend($this->fileService, $this->lockService, $absolute);
 		$server->on('propFind', [$this, 'customProperties']);
 		parent::initialize($server);
 	}

--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -30,6 +30,7 @@ use OCP\Files\Lock\ILock;
 use OCP\Files\Lock\ILockManager;
 use OCP\Files\Lock\LockContext;
 use OCP\Lock\ManuallyLockedException;
+use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 use Test\TestCase;
 use Test\Util\User\Dummy;
@@ -43,6 +44,8 @@ class LockFeatureTest extends TestCase {
 
 	private LockManager $lockManager;
 	private IRootFolder $rootFolder;
+	private ITimeFactory $timeFactory;
+	private IShareManager $shareManager;
 	private ?int $time = null;
 
 	public static function setUpBeforeClass(): void {


### PR DESCRIPTION
- Fix "Creation of dynamic property OCA\\FilesLock\\DAV\\LockBackend::$server is deprecated" by removing it.
- Creation of dynamic property LockFeatureTest::$shareManager is deprecated