### PR TITLE
fix: Show lock status for read only files and allow unlocking

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,7 @@ const inlineAction = new FileAction({
 		const node = nodes[0]
 		const state = getLockStateFromAttributes(node)
 
-		return (node.permissions & Permission.UPDATE) !== 0 && state.isLocked
+		return state.isLocked
 	},
 })
 
@@ -115,8 +115,10 @@ const menuAction = new FileAction({
 		}
 
 		const canToggleLock = canLock(nodes[0]) || canUnlock(nodes[0])
+		const isLocked = getLockStateFromAttributes(nodes[0]).isLocked
+		const isUpdatable = (nodes[0].permissions & Permission.UPDATE) !== 0
 
-		return nodes[0].type === FileType.File && canToggleLock && (nodes[0].permissions & Permission.UPDATE) !== 0
+		return nodes[0].type === FileType.File && canToggleLock && (isUpdatable || isLocked)
 	},
 
 	async exec(node: Node) {


### PR DESCRIPTION
Fix #305 

There may be cases where a file is locked but the lock owner no longer has write permissions. This PR ensures that
- The unlock option is always available if possible
- We also always show the lock status (which was not the case before on read only files
