### PR TITLE
fix: Show lock status for read only files and allow unlocking

### DIFF
--- a/js/files.js
+++ b/js/files.js
@@ -107,7 +107,7 @@
 						return OC.generateUrl(`/avatar/${lockOwner}/32`)
 					}
 				},
-				permissions: OC.PERMISSION_UPDATE,
+				permissions: OC.PERMISSION_READ,
 				actionHandler: function () {}
 			})
 
@@ -127,7 +127,7 @@
 				mime: 'file',
 				order: -140,
 				type: OCA.Files.FileActions.TYPE_INLINE,
-				permissions: OC.PERMISSION_UPDATE,
+				permissions: OC.PERMISSION_READ,
 				actionHandler: self.switchLock
 			})
 		},


### PR DESCRIPTION
Fix #305 

Adapted backport of https://github.com/nextcloud/files_lock/pull/306

Unfortunately the files app on 27 lacks the ability to provide our own condition on when to render an action. We should therefore just always show it.