### PR TITLE
test: Add test for extending locks

### DIFF
--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -6,15 +6,20 @@
 
 use OC\Files\Lock\LockManager;
 use OCA\FilesLock\AppInfo\Application;
+use OCA\FilesLock\Model\FileLock;
 use OCA\FilesLock\Service\ConfigService;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\Files\Lock\ILock;
 use OCP\Files\Lock\ILockManager;
 use OCP\Files\Lock\LockContext;
+use OCP\IConfig;
+use OCP\IUserManager;
 use OCP\Lock\ManuallyLockedException;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 use Test\Util\User\Dummy;
 
@@ -25,25 +30,25 @@ class LockFeatureTest extends TestCase {
 	public const TEST_USER1 = "test-user1";
 	public const TEST_USER2 = "test-user2";
 
-	private LockManager $lockManager;
-	private IRootFolder $rootFolder;
-	private ITimeFactory $timeFactory;
-	private IShareManager $shareManager;
-	private ?int $time = null;
+	protected LockManager $lockManager;
+	protected IRootFolder $rootFolder;
+	protected ITimeFactory&MockObject $timeFactory;
+	protected IShareManager $shareManager;
+	protected ?int $time = null;
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		$backend = new Dummy();
 		$backend->createUser(self::TEST_USER1, self::TEST_USER1);
 		$backend->createUser(self::TEST_USER2, self::TEST_USER2);
-		\OC::$server->getUserManager()->registerBackend($backend);
+		\OCP\Server::get(IUserManager::class)->registerBackend($backend);
 	}
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->time = null;
-		$this->lockManager = \OC::$server->get(ILockManager::class);
-		$this->rootFolder = \OC::$server->get(IRootFolder::class);
+		$this->lockManager = \OCP\Server::get(ILockManager::class);
+		$this->rootFolder = \OCP\Server::get(IRootFolder::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->timeFactory->expects(self::any())
 			->method('getTime')
@@ -54,22 +59,23 @@ class LockFeatureTest extends TestCase {
 				return time();
 			});
 		$folder = $this->loginAndGetUserFolder(self::TEST_USER1);
-		$folder->delete('testfile');
-		$folder->delete('testfile2');
-		$folder->delete('testfile3');
+		$folder->delete('test-file');
+		$folder->delete('test-file2');
+		$folder->delete('test-file3');
 		\OC_Hook::$thrownExceptions = [];
 		$this->overwriteService(ITimeFactory::class, $this->timeFactory);
 	}
 
 	public function testLockUser() {
 		$file = $this->loginAndGetUserFolder(self::TEST_USER1)
-			->newFile('testfile', 'AAA');
+			->newFile('test-file', 'AAA');
 		$this->shareFileWithUser($file, self::TEST_USER1, self::TEST_USER2);
 		$this->lockManager->lock(new LockContext($file, ILock::TYPE_USER, self::TEST_USER1));
 		$file->putContent('BBB');
 
+		/** @var File */
 		$file = $this->loginAndGetUserFolder(self::TEST_USER2)
-			->get('testfile');
+			->get('test-file');
 		try {
 			$file->putContent('CCC');
 			$this->fail('Expected to throw a ManuallyLockedException');
@@ -78,14 +84,16 @@ class LockFeatureTest extends TestCase {
 			self::assertEquals('BBB', $file->getContent());
 		}
 
+		/** @var File */
 		$file = $this->loginAndGetUserFolder(self::TEST_USER1)
-			->get('testfile');
+			->get('test-file');
 		$file->putContent('DDD');
 		self::assertEquals('DDD', $file->getContent());
 
 		$this->lockManager->unlock(new LockContext($file, ILock::TYPE_USER, self::TEST_USER1));
+		/** @var File */
 		$file = $this->loginAndGetUserFolder(self::TEST_USER2)
-			->get('testfile');
+			->get('test-file');
 		$file->putContent('EEE');
 		self::assertEquals('EEE', $file->getContent());
 	}
@@ -173,15 +181,16 @@ class LockFeatureTest extends TestCase {
 	}
 
 	public function testLockUserExpire() {
-		\OC::$server->getConfig()->setAppValue(Application::APP_ID, ConfigService::LOCK_TIMEOUT, 30);
+		\OCP\Server::get(IConfig::class)->setAppValue(Application::APP_ID, ConfigService::LOCK_TIMEOUT, 30);
 		$file = $this->loginAndGetUserFolder(self::TEST_USER1)
-			->newFile('testfile-expire', 'AAA');
+			->newFile('test-file-expire', 'AAA');
 		$this->shareFileWithUser($file, self::TEST_USER1, self::TEST_USER2);
 		$this->lockManager->lock(new LockContext($file, ILock::TYPE_USER, self::TEST_USER1));
 		$file->putContent('BBB');
 
+		/** @var File */
 		$file = $this->loginAndGetUserFolder(self::TEST_USER2)
-			->get('testfile-expire');
+			->get('test-file-expire');
 		try {
 			$file->putContent('CCC');
 			$this->fail('Expected to throw a ManuallyLockedException');
@@ -196,15 +205,16 @@ class LockFeatureTest extends TestCase {
 	}
 
 	public function testLockUserInfinite() {
-		\OC::$server->getConfig()->setAppValue(Application::APP_ID, ConfigService::LOCK_TIMEOUT, 0);
+		\OCP\Server::get(IConfig::class)->setAppValue(Application::APP_ID, ConfigService::LOCK_TIMEOUT, 0);
 		$file = $this->loginAndGetUserFolder(self::TEST_USER1)
-			->newFile('testfile-infinite', 'AAA');
+			->newFile('test-file-infinite', 'AAA');
 		$this->shareFileWithUser($file, self::TEST_USER1, self::TEST_USER2);
 		$this->lockManager->lock(new LockContext($file, ILock::TYPE_USER, self::TEST_USER1));
 		$file->putContent('BBB');
 
+		/** @var File */
 		$file = $this->loginAndGetUserFolder(self::TEST_USER2)
-			->get('testfile-infinite');
+			->get('test-file-infinite');
 		try {
 			$file->putContent('CCC');
 			$this->fail('Expected to throw a ManuallyLockedException');
@@ -214,8 +224,9 @@ class LockFeatureTest extends TestCase {
 		}
 
 		$this->toTheFuture(3600);
+		/** @var File */
 		$file = $this->loginAndGetUserFolder(self::TEST_USER2)
-			->get('testfile-infinite');
+			->get('test-file-infinite');
 		try {
 			$file->putContent('DDD');
 			$this->fail('Expected to throw a ManuallyLockedException');
@@ -227,7 +238,7 @@ class LockFeatureTest extends TestCase {
 
 	public function testLockApp() {
 		$file = $this->loginAndGetUserFolder(self::TEST_USER1)
-			->newFile('testfile2', 'AAA');
+			->newFile('test-file2', 'AAA');
 		$this->shareFileWithUser($file, self::TEST_USER1, self::TEST_USER2);
 		$scope = new LockContext($file, ILock::TYPE_APP, 'collaborative_app');
 		$this->lockManager->lock($scope);
@@ -255,7 +266,7 @@ class LockFeatureTest extends TestCase {
 
 	public function testLockDifferentApps() {
 		$file = $this->loginAndGetUserFolder(self::TEST_USER1)
-			->newFile('testfile3', 'AAA');
+			->newFile('test-file3', 'AAA');
 		$scope = new LockContext($file, ILock::TYPE_APP, 'collaborative_app');
 		$this->lockManager->lock($scope);
 
@@ -281,7 +292,7 @@ class LockFeatureTest extends TestCase {
 	public function testLockDifferentAppsPublic() {
 		self::logout();
 		$file = $this->rootFolder->getUserFolder(self::TEST_USER1)
-			->newFile('testfile_public', 'AAA');
+			->newFile('test-file_public', 'AAA');
 		$scope = new LockContext($file, ILock::TYPE_APP, 'collaborative_app');
 		$this->lockManager->lock($scope);
 
@@ -310,7 +321,7 @@ class LockFeatureTest extends TestCase {
 	}
 
 	private function shareFileWithUser(\OCP\Files\File $file, $owner, $user) {
-		$this->shareManager = \OC::$server->getShareManager();
+		$this->shareManager = \OCP\Server::get(IShareManager::class);
 		$share1 = $this->shareManager->newShare();
 		$share1->setNode($file)
 			->setSharedBy($owner)
@@ -329,11 +340,11 @@ class LockFeatureTest extends TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 		$folder = $this->rootFolder->getUserFolder(self::TEST_USER1);
-		$folder->delete('testfile');
+		$folder->delete('test-file');
 		$folder->delete('etag_test');
-		$folder->delete('testfile2');
-		$folder->delete('testfile3');
-		$folder->delete('testfile-infinite');
-		$folder->delete('testfile_public');
+		$folder->delete('test-file2');
+		$folder->delete('test-file3');
+		$folder->delete('test-file-infinite');
+		$folder->delete('test-file_public');
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,8 @@ require_once __DIR__ . '/../../../lib/base.php';
 \OC::$composerAutoloader->addPsr4('Tests\\', OC::$SERVERROOT . '/tests/', true);
 
 // load all enabled apps
-\OC_App::loadApps();
+\OCP\Server::get(\OCP\App\IAppManager::class)->loadApps();
+\OCP\Server::get(\OCP\App\IAppManager::class)->enableApp('files_lock', true);
+\OC_App::updateApp('files_lock');
 
 set_include_path(get_include_path() . PATH_SEPARATOR . '/usr/share/php');


### PR DESCRIPTION
1. Refactor deprecated code in tests - replace with current alternative
2. Add two test cases for extending locks to prevent regressions.
3. Fix bootstrap for local run¹


¹ This one I am not sure of, how do you run the test locally? Because it needs to be enabled,
but tests (autotest) use a fresh DB so no external apps are enabled. This is the only way I was able to test it locally.