### PR TITLE
[stable29] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -597,9 +597,9 @@
       "peer": true
     },
     "node_modules/@buttercup/fetch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@buttercup/fetch/-/fetch-0.1.2.tgz",
-      "integrity": "sha512-mDBtsysQ0Gnrp4FamlRJGpu7HUHwbyLC4uUav1I7QAqThFAa/4d1cdZCxrV5gKvh6zO1fu95bILNJi4Y2hALhQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@buttercup/fetch/-/fetch-0.2.1.tgz",
+      "integrity": "sha512-sCgECOx8wiqY8NN1xN22BqqKzXYIG2AicNLlakOAI4f0WgyLVUbAigMf8CZhBtJxdudTcB1gD5lciqi44jwJvg==",
       "optionalDependencies": {
         "node-fetch": "^3.3.0"
       }
@@ -2279,21 +2279,34 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0.tgz",
-      "integrity": "sha512-zk5oIuVDyk2gWBKCJ+0B1HE3VjhuGnz2iLNbTcbRuTjMYb6aYCAEn1LY0dXbUQG93ehndYJCOdaYri/TaGrlXw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.2.0.tgz",
+      "integrity": "sha512-3EQBR758bzvqcNRzcp1etHGGkCZgK6wS9or8iQpzIOKf4B2tAe1O+hXA8GzPiQ5ZlGIPblOlMOEMlRg1KD49hg==",
       "dependencies": {
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/logger": "^2.7.0",
         "@nextcloud/paths": "^2.1.0",
-        "@nextcloud/router": "^2.2.0",
+        "@nextcloud/router": "^3.0.0",
+        "cancelable-promise": "^4.3.1",
         "is-svg": "^5.0.0",
-        "webdav": "^5.3.0"
+        "webdav": "^5.5.0"
       },
       "engines": {
         "node": "^20.0.0",
         "npm": "^9.0.0"
+      }
+    },
+    "node_modules/@nextcloud/files/node_modules/@nextcloud/router": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.1.tgz",
+      "integrity": "sha512-Ci/uD3x8OKHdxSqXL6gRJ+mGJOEXjeiHjj7hqsZqVTsT7kOrCjDf0/J8z5RyLlokKZ0IpSe+hGxgi3YB7Gpw3Q==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/l10n": {
@@ -3679,11 +3692,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -4348,6 +4361,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cancelable-promise": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-4.3.1.tgz",
+      "integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A=="
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001651",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
@@ -4903,7 +4921,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -5185,9 +5202,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
     },
     "node_modules/domutils": {
       "version": "3.1.0",
@@ -5223,9 +5240,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -6443,7 +6460,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "optional": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -6560,7 +6576,6 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "optional": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -7005,6 +7020,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "bin": {
         "he": "bin/he"
       }
@@ -9685,9 +9701,9 @@
       "dev": true
     },
     "node_modules/layerr": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/layerr/-/layerr-2.0.1.tgz",
-      "integrity": "sha512-z0730CwG/JO24evdORnyDkwG1Q7b7mF2Tp1qRQ0YvrMMARbt1DFG694SOv439Gm7hYKolyZyaB49YIrYIfZBdg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
+      "integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA=="
     },
     "node_modules/less": {
       "version": "4.2.0",
@@ -10022,13 +10038,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -10246,7 +10262,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "optional": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -10255,7 +10270,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "optional": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -11576,9 +11590,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -13164,9 +13178,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
-      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -13830,35 +13844,35 @@
       }
     },
     "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "optional": true,
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/webdav": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.3.0.tgz",
-      "integrity": "sha512-xRu/URZGCxDPXmT+9Gu6tNGvlETBwjcuz69lx/6Qlq/0q3Gu2GSVyRt+mP0vTlLFfaY3xZ5O/SPTQ578tC/45Q==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.7.1.tgz",
+      "integrity": "sha512-JVPn3nLxXJfHSRvennHsOrDYjFLkilZ1Qlw8Ff6hpqp6AvkgF7a//aOh5wA4rMp+sLZ1Km0V+iv0LyO1FIwtXg==",
       "dependencies": {
-        "@buttercup/fetch": "^0.1.1",
+        "@buttercup/fetch": "^0.2.1",
         "base-64": "^1.0.0",
         "byte-length": "^1.0.2",
-        "fast-xml-parser": "^4.2.4",
-        "he": "^1.2.0",
-        "hot-patcher": "^2.0.0",
-        "layerr": "^2.0.1",
+        "entities": "^5.0.0",
+        "fast-xml-parser": "^4.4.1",
+        "hot-patcher": "^2.0.1",
+        "layerr": "^3.0.0",
         "md5": "^2.3.0",
-        "minimatch": "^7.4.6",
+        "minimatch": "^9.0.5",
         "nested-property": "^4.0.0",
+        "node-fetch": "^3.3.2",
         "path-posix": "^1.0.0",
         "url-join": "^5.0.0",
         "url-parse": "^1.5.10"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/webdav/node_modules/brace-expansion": {
@@ -13869,15 +13883,26 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/webdav/node_modules/entities": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-5.0.0.tgz",
+      "integrity": "sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/webdav/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"


### PR DESCRIPTION
# Audit report

This audit fix resolves 10 of the total 14 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [axios](#user-content-axios)
* [dompurify](#user-content-dompurify)
* [elliptic](#user-content-elliptic)
* [micromatch](#user-content-micromatch)
* [node-gettext](#user-content-node-gettext)
* [rollup](#user-content-rollup)
* [vite](#user-content-vite)
* [vue-tsc](#user-content-vue-tsc)
## Fixed vulnerabilities

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### axios <a href="#user-content-axios" id="axios">#</a>
* Server-Side Request Forgery in axios
* Severity: **high**
* Reference: [https://github.com/advisories/GHSA-8hc4-vh64-cxmj](https://github.com/advisories/GHSA-8hc4-vh64-cxmj)
* Affected versions: 1.3.2 - 1.7.3
* Package usage:
  * `node_modules/axios`

### dompurify <a href="#user-content-dompurify" id="dompurify">#</a>
* DOMPurify allows tampering by prototype pollution
* Severity: **high** (CVSS 7)
* Reference: [https://github.com/advisories/GHSA-mmhx-hmjr-r674](https://github.com/advisories/GHSA-mmhx-hmjr-r674)
* Affected versions: 3.0.0 - 3.1.2
* Package usage:
  * `node_modules/dompurify`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Elliptic's EDDSA missing signature length check
* Severity: **low** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-f7q4-pwc6-w24p](https://github.com/advisories/GHSA-f7q4-pwc6-w24p)
* Affected versions: 2.0.0 - 6.5.6
* Package usage:
  * `node_modules/elliptic`

### micromatch <a href="#user-content-micromatch" id="micromatch">#</a>
* Regular Expression Denial of Service (ReDoS) in micromatch
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv)
* Affected versions: <4.0.8
* Package usage:
  * `node_modules/micromatch`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **moderate** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### rollup <a href="#user-content-rollup" id="rollup">#</a>
* DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS
* Severity: **high** (CVSS 6.4)
* Reference: [https://github.com/advisories/GHSA-gcx4-mw62-g8wm](https://github.com/advisories/GHSA-gcx4-mw62-g8wm)
* Affected versions: 3.0.0 - 3.29.4
* Package usage:
  * `node_modules/rollup`

### vite <a href="#user-content-vite" id="vite">#</a>
* Vite DOM Clobbering gadget found in vite bundled scripts that leads to XSS
* Severity: **moderate** (CVSS 6.4)
* Reference: [https://github.com/advisories/GHSA-64vr-g452-qvp3](https://github.com/advisories/GHSA-64vr-g452-qvp3)
* Affected versions: 4.0.0 - 4.5.3
* Package usage:
  * `node_modules/vite`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`