### PR TITLE
fix(ci): litmus test with current upload-artifact

### DIFF
--- a/.github/workflows/litmus.yml
+++ b/.github/workflows/litmus.yml
@@ -109,7 +109,7 @@ jobs:
         run: cat data/nextcloud.log
 
       - name: Upload litmus logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Upload litmus log
@@ -117,7 +117,7 @@ jobs:
           retention-days: 5
 
       - name: Upload nextcloud logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Upload nextcloud log


### PR DESCRIPTION
The older versions were deprecated earlier this year:
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
