### PR TITLE
fix: Use proper user when unlocking an app locked file with occ

### DIFF
--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -259,7 +259,7 @@ class LockService {
 		}
 
 		if ($force) {
-			$userId = $lock->getOwner();
+			$userId = in_array($lock->getType(), [ILock::TYPE_USER, ILock::TYPE_TOKEN]) ? $lock->getOwner() : $userId;
 			$lockType = $lock->getType();
 		}
 


### PR DESCRIPTION
First quick fix for #451 

Steps to reproduce:
- Setup the groupfolders app and create a groupfolder
- Create a text file and open it in the group folder
- Try to unlock it with occ