### PR TITLE
fix: Use icons instead of avatar for locking indication

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -61,16 +61,16 @@ export const getInfoLabel = (node: Node): string => {
 
 	if (state.lockOwnerType === LockType.User) {
 		return state.isLocked
-			? t('files_lock', 'Locked by {user}', { user: state.lockOwnerDisplayName })
+			? t('files_lock', 'Manually locked by {user}', { user: state.lockOwnerDisplayName })
 			: ''
 
 	} else if (state.lockOwnerType === LockType.App) {
 		return state.isLocked
-			? t('files_lock', 'Locked by {app}', { app: state.lockOwnerDisplayName })
+			? t('files_lock', 'Locked by editing online in {app}', { app: state.lockOwnerDisplayName })
 			: ''
 	} else {
 		return state.isLocked
-			? t('files_lock', 'Locked by {user}', { user: state.lockOwnerDisplayName })
+			? t('files_lock', 'Automatically locked by {user}', { user: state.lockOwnerDisplayName })
 			: ''
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,6 @@ import { lockFile, unlockFile } from './api'
 import { LockType } from './types'
 import {
 	canLock, canUnlock,
-	generateAvatarSvg,
 	getInfoLabel,
 	getLockStateFromAttributes,
 } from './helper'
@@ -29,6 +28,8 @@ import '@nextcloud/dialogs/style.css'
 import LockSvg from '@mdi/svg/svg/lock.svg?raw'
 import LockOpenSvg from '@mdi/svg/svg/lock-open-variant.svg?raw'
 import LockEditSvg from '@mdi/svg/svg/pencil-lock.svg?raw'
+import LockMonitorSvg from '@mdi/svg/svg/monitor-lock.svg?raw'
+import LockAccountSvg from '@mdi/svg/svg/account-lock.svg?raw'
 
 const switchLock = async (node: Node) => {
 	try {
@@ -73,12 +74,16 @@ const inlineAction = new FileAction({
 			return ''
 		}
 
-		if (state.isLocked && state.lockOwnerType !== LockType.App && state.lockOwner !== getCurrentUser()?.uid) {
-			return generateAvatarSvg(state.lockOwner)
+		if (state.lockOwnerType === LockType.Token) {
+			return LockMonitorSvg
 		}
 
 		if (state.lockOwnerType === LockType.App) {
 			return LockEditSvg
+		}
+
+		if (state.lockOwner !== getCurrentUser()?.uid) {
+			return LockAccountSvg
 		}
 
 		return LockSvg


### PR DESCRIPTION
Fix #350 

This would be my proposal based on the discussion in the ticket and with @jancborchardt 

@marcoambrosini @Jerome-Herbinet I would be very interested in your feedback on this one.

#### File is manually locked by myself

<img width="925" alt="Screenshot 2024-12-19 at 14 10 22" src="https://github.com/user-attachments/assets/9835438b-6302-41d9-bc91-20409b69f218" />

#### File is locked manually by another user

<img width="924" alt="Screenshot 2024-12-19 at 14 12 01" src="https://github.com/user-attachments/assets/c18231b5-157d-4ce7-ad66-dfd2e3074ca7" />

#### File has a collaborative automated lock by text/office (e.g. others are editing it collaboratively right now)

<img width="927" alt="Screenshot 2024-12-19 at 14 10 53" src="https://github.com/user-attachments/assets/55ee09e3-e379-4957-a7e5-26587d6f343f" />

#### File is locked automatically by a desktop client or webdav client

<img width="928" alt="Screenshot 2024-12-19 at 14 11 35" src="https://github.com/user-attachments/assets/88794053-ac2e-4768-b476-80ef0280efff" />


