### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,9 +1667,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.21.0.tgz",
-      "integrity": "sha512-at06uh2JJkn8dV3Yzyoag2z1g6omad8MZ8yKWE+9ZAGP+kaysbnI5q3lB7KXu8SVRtX3Rex8/oal0jgsbb6Spg==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.22.0.tgz",
+      "integrity": "sha512-6smeLUVLl8lqh+ia9j+m3nk9fnjra/YNgNO8RI1He8LRuojB9ZQtIy3kGcqIN1BOi6fx9qLiBEkobazWzMmiSw==",
       "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -1707,6 +1707,7 @@
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
+        "tabbable": "^6.2.0",
         "tributejs": "^5.1.3",
         "unified": "^11.0.1",
         "unist-builder": "^4.0.0",


### PR DESCRIPTION
# Audit report

This audit fix resolves 13 of the total 17 vulnerabilities found in your project.

## Updated dependencies
* [@linusborg/vue-simple-portal](#user-content-\@linusborg\/vue-simple-portal)
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [@nextcloud/vue-select](#user-content-\@nextcloud\/vue-select)
* [floating-vue](#user-content-floating-vue)
* [node-gettext](#user-content-node-gettext)
* [vue](#user-content-vue)
* [vue-frag](#user-content-vue-frag)
* [vue-resize](#user-content-vue-resize)
* [vue-tsc](#user-content-vue-tsc)
* [vue2-datepicker](#user-content-vue2-datepicker)
## Fixed vulnerabilities

### @linusborg/vue-simple-portal <a href="#user-content-\@linusborg\/vue-simple-portal" id="\@linusborg\/vue-simple-portal">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@linusborg/vue-simple-portal`

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@linusborg/vue-simple-portal](#user-content-\@linusborg\/vue-simple-portal)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue-select](#user-content-\@nextcloud\/vue-select)
  * [floating-vue](#user-content-floating-vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
  * [vue2-datepicker](#user-content-vue2-datepicker)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vue`

### @nextcloud/vue-select <a href="#user-content-\@nextcloud\/vue-select" id="\@nextcloud\/vue-select">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vue-select`

### floating-vue <a href="#user-content-floating-vue" id="floating-vue">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-resize](#user-content-vue-resize)
* Affected versions: <=1.0.0-beta.19
* Package usage:
  * `node_modules/floating-vue`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **high** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### vue <a href="#user-content-vue" id="vue">#</a>
* ReDoS vulnerability in vue package that is exploitable through inefficient regex evaluation in the parseHTML function
* Severity: **low** (CVSS 3.7)
* Reference: [https://github.com/advisories/GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
* Affected versions: 2.0.0-alpha.1 - 2.7.16
* Package usage:
  * `node_modules/vue`

### vue-frag <a href="#user-content-vue-frag" id="vue-frag">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: >=1.3.1
* Package usage:
  * `node_modules/vue-frag`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`

### vue2-datepicker <a href="#user-content-vue2-datepicker" id="vue2-datepicker">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: <=1.9.8 || 3.0.2 - 3.11.1
* Package usage:
  * `node_modules/vue2-datepicker`