### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,6 +1201,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 12 vulnerabilities found in your project.

## Updated dependencies
* [@linusborg/vue-simple-portal](#user-content-\@linusborg\/vue-simple-portal)
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [@nextcloud/vue-select](#user-content-\@nextcloud\/vue-select)
* [floating-vue](#user-content-floating-vue)
* [node-gettext](#user-content-node-gettext)
* [vue](#user-content-vue)
* [vue-frag](#user-content-vue-frag)
* [vue-resize](#user-content-vue-resize)
* [vue2-datepicker](#user-content-vue2-datepicker)
## Fixed vulnerabilities

### @linusborg/vue-simple-portal <a href="#user-content-\@linusborg\/vue-simple-portal" id="\@linusborg\/vue-simple-portal">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@linusborg/vue-simple-portal`

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@linusborg/vue-simple-portal](#user-content-\@linusborg\/vue-simple-portal)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue-select](#user-content-\@nextcloud\/vue-select)
  * [floating-vue](#user-content-floating-vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
  * [vue2-datepicker](#user-content-vue2-datepicker)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vue`

### @nextcloud/vue-select <a href="#user-content-\@nextcloud\/vue-select" id="\@nextcloud\/vue-select">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vue-select`

### floating-vue <a href="#user-content-floating-vue" id="floating-vue">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-resize](#user-content-vue-resize)
* Affected versions: <=1.0.0-beta.19
* Package usage:
  * `node_modules/floating-vue`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **high** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### vue <a href="#user-content-vue" id="vue">#</a>
* ReDoS vulnerability in vue package that is exploitable through inefficient regex evaluation in the parseHTML function
* Severity: **low** (CVSS 3.7)
* Reference: [https://github.com/advisories/GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
* Affected versions: 2.0.0-alpha.1 - 2.7.16
* Package usage:
  * `node_modules/vue`

### vue-frag <a href="#user-content-vue-frag" id="vue-frag">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: >=1.3.1
* Package usage:
  * `node_modules/vue-frag`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue2-datepicker <a href="#user-content-vue2-datepicker" id="vue2-datepicker">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: <=1.9.8 || 3.0.2 - 3.11.1
* Package usage:
  * `node_modules/vue2-datepicker`