### PR TITLE
fix: Hide empty inline menu entry in grid view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import {
 import { getCurrentUser } from '@nextcloud/auth'
 
 import '@nextcloud/dialogs/style.css'
+import './styles.css'
 
 import LockSvg from '@mdi/svg/svg/lock.svg?raw'
 import LockOpenSvg from '@mdi/svg/svg/lock-open-variant.svg?raw'
@@ -97,6 +98,7 @@ const inlineAction = new FileAction({
 
 		// FIXME: Currently enabled is not re-evaluated when emitting an updated node object through files:node:updated
 		// Therefor we need to also have a unlocked state as the inline action is then always rendered
+		// We currently hide them for the grid view via css
 		return true
 
 		const node = nodes[0]

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* The grid view currently does not properly handle inline actions, we hide them for now */
+.action-item__popper .action.files-list__row-action-lock_inline,
+.files-list--grid .action.files-list__row-action-lock_inline {
+    display: none;
+}


### PR DESCRIPTION
The grid view currently does not support inline actions and renders them in the menu. This is a quick fix to address https://github.com/nextcloud/server/issues/51452 to align with our other quick fix in https://github.com/nextcloud/files_lock/blob/main/src/main.ts#L98-L100