### PR TITLE
chore(ci): fix auto merge in ocp workflow

### DIFF
--- a/.github/workflows/update-nextcloud-ocp-approve-merge.yml
+++ b/.github/workflows/update-nextcloud-ocp-approve-merge.yml
@@ -58,6 +58,6 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: startsWith(steps.branchname.outputs.branch, 'automated/noid/') && endsWith(steps.branchname.outputs.branch, 'update-nextcloud-ocp')
-        run: gh pr merge --merge --auto "1"
+        run: gh pr merge --merge --auto ${{ github.event.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the actual pr number.

## Before:

![grafik](https://github.com/user-attachments/assets/53cc31c2-ec13-4f3a-96c1-451ae9858b26)

https://github.com/nextcloud/files_lock/actions/runs/14014926384/job/39239397182
