### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -231,12 +231,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "cff0b63cf4d38d363cbf5d19cdab0bcf0680e1dc"
+                "reference": "587ae7f09700ce7d081b8bdc14064791b84fd5fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cff0b63cf4d38d363cbf5d19cdab0bcf0680e1dc",
-                "reference": "cff0b63cf4d38d363cbf5d19cdab0bcf0680e1dc",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/587ae7f09700ce7d081b8bdc14064791b84fd5fb",
+                "reference": "587ae7f09700ce7d081b8bdc14064791b84fd5fb",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +272,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-07-12T00:56:41+00:00"
+            "time": "2025-07-17T00:56:49+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency