### PR TITLE
Fix/lock deletion

### DIFF
--- a/lib/Cron/Unlock.php
+++ b/lib/Cron/Unlock.php
@@ -25,10 +25,10 @@ class Unlock extends TimedJob {
 	}
 
 	protected function run($argument): void {
-		$this->manageTimeoutLock();
+		$this->deleteExpiredLocks();
 	}
 
-	private function manageTimeoutLock(): void {
-		$this->lockService->removeLocks($this->lockService->getDeprecatedLocks());
+	private function deleteExpiredLocks(): void {
+		$this->lockService->removeLocks($this->lockService->getDeprecatedLocks(1000));
 	}
 }

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -29,7 +29,7 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @param array $ids
 	 */
 	public function limitToIds(array $ids): void {
-		$this->limitArray('id', $ids);
+		$this->limitInArray('id', $ids);
 	}
 
 	public function limitToFileIds(array $ids): void {

--- a/lib/Db/LocksRequest.php
+++ b/lib/Db/LocksRequest.php
@@ -123,15 +123,20 @@ class LocksRequest extends LocksRequestBuilder {
 
 	/**
 	 * @param int $timeout in minutes
+	 * @param int $limit how many locks to retrieve (0 for all, default)
 	 *
 	 * @return FileLock[]
 	 * @throws Exception
 	 */
-	public function getLocksOlderThan(int $timeout): array {
+	public function getLocksOlderThan(int $timeout, int $limit = 0): array {
 		$now = \OC::$server->get(ITimeFactory::class)->getTime();
 		$oldCreationTime = $now - $timeout * 60;
 		$qb = $this->getLocksSelectSql();
 		$qb->andWhere($qb->expr()->lt('l.creation', $qb->createNamedParameter($oldCreationTime, IQueryBuilder::PARAM_INT)));
+
+		if ($limit !== 0) {
+			$qb->setMaxResults($limit);
+		}
 
 		return $this->getLocksFromRequest($qb);
 	}

--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -274,9 +274,11 @@ class LockService {
 
 
 	/**
+	 * @param int $limit how many locks to retrieve (0 for all, default)
+	 *
 	 * @return FileLock[]
 	 */
-	public function getDeprecatedLocks(): array {
+	public function getDeprecatedLocks(int $limit = 0): array {
 		$timeout = (int)$this->configService->getAppValue(ConfigService::LOCK_TIMEOUT);
 		if ($timeout === 0) {
 			$this->logger->notice(
@@ -286,7 +288,7 @@ class LockService {
 		}
 
 		try {
-			$locks = $this->locksRequest->getLocksOlderThan($timeout);
+			$locks = $this->locksRequest->getLocksOlderThan($timeout, $limit);
 		} catch (Exception $e) {
 			$this->logger->warning('Failed to get locks older then timeout', ['exception' => $e]);
 			return [];

--- a/lib/Tools/Db/ExtendedQueryBuilder.php
+++ b/lib/Tools/Db/ExtendedQueryBuilder.php
@@ -101,7 +101,7 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param array $ids
 	 */
 	public function limitToIds(array $ids): void {
-		$this->limitArray('id', $ids);
+		$this->limitInArray('id', $ids);
 	}
 
 	/**


### PR DESCRIPTION
Fix an issue in deleting expired locks, which prevented any expired locks from being deleted as soon as there was more than one expired lock.

The code was building a `DELETE ... WHERE id = # AND id = # AND id = # ...` which never deletes any row as long as more than one id is provided.

To prevent mass deletion due to the patch for users with many rows in the table, a limit of 1000 rows per-run has been added.