### PR TITLE
feat: add federated file locking

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -13,6 +13,7 @@ use OC\Files\Filesystem;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\FilesLock\Capability;
 use OCA\FilesLock\Listeners\LoadAdditionalScripts;
+use OCA\FilesLock\Listeners\PropfindPropertiesListener;
 use OCA\FilesLock\LockProvider;
 use OCA\FilesLock\Service\FileService;
 use OCA\FilesLock\Service\LockService;
@@ -21,6 +22,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Files\Events\BeforeRemotePropfindEvent;
 use OCP\Files\Lock\ILockManager;
 use OCP\IUserSession;
 use OCP\Server;
@@ -47,6 +49,10 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(
 			LoadAdditionalScriptsEvent::class,
 			LoadAdditionalScripts::class
+		);
+		$context->registerEventListener(
+			BeforeRemotePropfindEvent::class,
+			PropfindPropertiesListener::class
 		);
 	}
 

--- a/lib/Listeners/PropfindPropertiesListener.php
+++ b/lib/Listeners/PropfindPropertiesListener.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesLock\Listeners;
+
+use OCA\FilesLock\AppInfo\Application;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\BeforeRemotePropfindEvent;
+
+/**
+ * @template-implements IEventListener<BeforeRemotePropfindEvent>
+ */
+class PropfindPropertiesListener implements IEventListener {
+	public function handle(Event $event): void {
+		if (!($event instanceof BeforeRemotePropfindEvent)) {
+			return;
+		}
+
+		$event->addProperties([
+			Application::DAV_PROPERTY_LOCK,
+			Application::DAV_PROPERTY_LOCK_OWNER,
+			Application::DAV_PROPERTY_LOCK_OWNER_DISPLAYNAME,
+			Application::DAV_PROPERTY_LOCK_OWNER_TYPE,
+			Application::DAV_PROPERTY_LOCK_EDITOR,
+			Application::DAV_PROPERTY_LOCK_TIME,
+			Application::DAV_PROPERTY_LOCK_TIMEOUT,
+			Application::DAV_PROPERTY_LOCK_TOKEN,
+		]);
+	}
+}

--- a/lib/LockProvider.php
+++ b/lib/LockProvider.php
@@ -20,17 +20,13 @@ class LockProvider implements ILockProvider {
 	}
 
 	public function getLocks(int $fileId): array {
-		try {
-			$lock = $this->lockService->getLockFromFileId($fileId);
-			$this->lockService->injectMetadata($lock);
-		} catch (Exceptions\LockNotFoundException $e) {
+		$lock = $this->lockService->getLockForNodeId($fileId);
+		if (!$lock) {
 			return [];
 		}
 
-		if ($lock) {
-			return [$lock];
-		}
-		return [];
+		$this->lockService->injectMetadata($lock);
+		return [$lock];
 	}
 
 	/**

--- a/lib/Storage/LockWrapper.php
+++ b/lib/Storage/LockWrapper.php
@@ -134,7 +134,7 @@ class LockWrapper extends Wrapper {
 			//This is a rename of the transfer file to the original file
 			if (strpos($part, '.ocTransferId') === 0) {
 				return $this->checkPermissions($path2, Constants::PERMISSION_CREATE)
-					   && parent::rename($path1, $path2);
+					&& parent::rename($path1, $path2);
 			}
 		}
 		$permissions
@@ -145,9 +145,9 @@ class LockWrapper extends Wrapper {
 		}
 
 		return $this->checkPermissions($sourceParent, Constants::PERMISSION_DELETE)
-			   && $this->checkPermissions($path1, Constants::PERMISSION_UPDATE & Constants::PERMISSION_READ)
-			   && $this->checkPermissions($path2, $permissions)
-			   && parent::rename($path1, $path2);
+			&& $this->checkPermissions($path1, Constants::PERMISSION_UPDATE & Constants::PERMISSION_READ)
+			&& $this->checkPermissions($path2, $permissions)
+			&& parent::rename($path1, $path2);
 	}
 
 	public function copy($path1, $path2): bool {
@@ -155,10 +155,10 @@ class LockWrapper extends Wrapper {
 			= $this->file_exists($path2) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
 
 		return $this->checkPermissions($path2, $permissions)
-			   && $this->checkPermissions(
-			   	$path1, Constants::PERMISSION_READ
-			   )
-			   && parent::copy($path1, $path2);
+			&& $this->checkPermissions(
+				$path1, Constants::PERMISSION_READ
+			)
+			&& parent::copy($path1, $path2);
 	}
 
 	public function touch($path, $mtime = null): bool {
@@ -174,12 +174,12 @@ class LockWrapper extends Wrapper {
 
 	public function rmdir($path): bool {
 		return $this->checkPermissions($path, Constants::PERMISSION_DELETE)
-			   && parent::rmdir($path);
+			&& parent::rmdir($path);
 	}
 
 	public function unlink($path): bool {
 		return $this->checkPermissions($path, Constants::PERMISSION_DELETE)
-			   && parent::unlink($path);
+			&& parent::unlink($path);
 	}
 
 	public function file_put_contents($path, $data): int|float|false {


### PR DESCRIPTION
## Summary
Implements federated file locking, allowing locks to propagate between servers.

## Changes
~~- Added OCS api endpoint to check locks by share token~~
- Request locks using webdav propfind 
- Check remote locks before allowing file operations
- Show hostname in lock display for remote locks (e.g. `admin@nextcloud.local`)

Fixes https://github.com/nextcloud/files_lock/issues/896

Requires https://github.com/nextcloud/server/pull/57914