### PR TITLE
fix: lock cache invalidation

### DIFF
--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -162,6 +162,7 @@ class LockService {
 				);
 				$this->logger->notice('extending existing lock', ['fileLock' => $known]);
 				$this->locksRequest->update($known);
+				$this->lockCache[$lockScope->getNode()->getId()] = $known;
 				$this->injectMetadata($known);
 				return $known;
 			}
@@ -204,6 +205,7 @@ class LockService {
 		}
 
 		$this->locksRequest->delete($known);
+		$this->lockCache[$lock->getNode()->getId()] = false;
 		$this->propagateEtag($lock);
 		$this->injectMetadata($known);
 		return $known;

--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -60,10 +60,16 @@ class LockFeatureTest extends TestCase {
 				}
 				return time();
 			});
+
+		// switch to user2 to clear stale cache
+		$this->loginAndGetUserFolder(self::TEST_USER2);
+
 		$folder = $this->loginAndGetUserFolder(self::TEST_USER1);
 		$folder->delete('test-file');
 		$folder->delete('test-file2');
 		$folder->delete('test-file3');
+		$folder->delete('etag_test');
+
 		\OC_Hook::$thrownExceptions = [];
 		$this->overwriteService(ITimeFactory::class, $this->timeFactory);
 		$this->toTheFuture(0);


### PR DESCRIPTION
PHPUnit tests were failing due to stale caches.
Fix stale lock cache after extend/unlock and clear stale cache between tests.

Fixes https://github.com/nextcloud/files_lock/issues/1003