### PR TITLE
fix: migrate FileAction to IFileAction for @nextcloud/files v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nextcloud/axios": "^2.5.2",
         "@nextcloud/dialogs": "^7.1.0",
         "@nextcloud/event-bus": "^3.3.3",
-        "@nextcloud/files": "^4.0.0-rc.0",
+        "@nextcloud/files": "^4.0.0",
         "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/vue": "^9.5.0",
@@ -1851,9 +1851,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "4.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0-rc.0.tgz",
-      "integrity": "sha512-zg/TQH4oQQYlntzkcWokjKIkTX39maiYXceDYrE3OnzCYZv0IKmOH3+pQer58/Z9QfsU8huTnzHblhzVNsJvAA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
+      "integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",
@@ -1865,7 +1865,7 @@
         "@nextcloud/sharing": "^0.3.0",
         "is-svg": "^6.1.0",
         "typescript-event-target": "^1.1.2",
-        "webdav": "^5.8.0"
+        "webdav": "^5.9.0"
       },
       "engines": {
         "node": "^24.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@nextcloud/axios": "^2.5.2",
     "@nextcloud/dialogs": "^7.1.0",
     "@nextcloud/event-bus": "^3.3.3",
-    "@nextcloud/files": "^4.0.0-rc.0",
+    "@nextcloud/files": "^4.0.0",
     "@nextcloud/l10n": "^3.4.1",
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/vue": "^9.5.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-	FileAction,
+	type IFileAction,
 	type Node,
 	type INode,
 	FileType,
@@ -80,7 +80,7 @@ const getLockStateIcon = (node: Node) => {
 	return LockSvg
 }
 
-const inlineAction = new FileAction({
+const inlineAction: IFileAction = {
 	id: 'lock_inline',
 	title: ({ nodes }: { nodes: INode[] }) => nodes.length === 1 ? getInfoLabel(nodes[0] as Node) : '',
 	inline: () => true,
@@ -104,9 +104,9 @@ const inlineAction = new FileAction({
 
 		return state.isLocked
 	},
-})
+}
 
-const menuInfo = new FileAction({
+const menuInfo: IFileAction = {
 	id: 'lock_info',
 	order: 25,
 	displayName: ({ nodes }: { nodes: INode[] }) => getInfoLabel(nodes[0] as Node),
@@ -126,8 +126,9 @@ const menuInfo = new FileAction({
 	async exec() {
 		return null
 	},
-})
-const menuAction = new FileAction({
+}
+
+const menuAction: IFileAction = {
 	id: 'lock',
 	order: 25,
 
@@ -185,8 +186,7 @@ const menuAction = new FileAction({
 
 		return await switchLock(node)
 	},
-
-})
+}
 
 registerFileAction(inlineAction)
 registerFileAction(menuInfo)


### PR DESCRIPTION
Migrate from `FileAction()` to `IFileAction` for  `@nextcloud/files` v4, and update the dependency from `rc.0` to stable.

Fixes #1026 