### PR TITLE
perf: don't needlessly call getFirstNodeById for every file during a propfind

### DIFF
--- a/lib/DAV/LockPlugin.php
+++ b/lib/DAV/LockPlugin.php
@@ -103,13 +103,13 @@ class LockPlugin extends SabreLockPlugin {
 
 		$nodeId = $node->getId();
 
-		$propFind->handle(Application::DAV_PROPERTY_LOCK, function () use ($nodeId) {
-			$lock = $this->lockService->getLockForNodeId($nodeId);
+		$propFind->handle(Application::DAV_PROPERTY_LOCK, function () use ($nodeId, $node) {
+			$lock = $this->lockService->getLockForNodeId($nodeId, $node->getNode());
 			return $lock instanceof FileLock;
 		});
 
-		$propFind->handle(Application::DAV_PROPERTY_LOCK_OWNER, function () use ($nodeId) {
-			$lock = $this->lockService->getLockForNodeId($nodeId);
+		$propFind->handle(Application::DAV_PROPERTY_LOCK_OWNER, function () use ($nodeId, $node) {
+			$lock = $this->lockService->getLockForNodeId($nodeId, $node->getNode());
 
 			if ($lock === false) {
 				return null;
@@ -122,8 +122,8 @@ class LockPlugin extends SabreLockPlugin {
 			return $lock->getOwner();
 		});
 
-		$propFind->handle(Application::DAV_PROPERTY_LOCK_TIME, function () use ($nodeId) {
-			$lock = $this->lockService->getLockForNodeId($nodeId);
+		$propFind->handle(Application::DAV_PROPERTY_LOCK_TIME, function () use ($nodeId, $node) {
+			$lock = $this->lockService->getLockForNodeId($nodeId, $node->getNode());
 
 			if ($lock === false) {
 				return null;
@@ -132,8 +132,8 @@ class LockPlugin extends SabreLockPlugin {
 			return $lock->getCreatedAt();
 		});
 
-		$propFind->handle(Application::DAV_PROPERTY_LOCK_TIMEOUT, function () use ($nodeId) {
-			$lock = $this->lockService->getLockForNodeId($nodeId);
+		$propFind->handle(Application::DAV_PROPERTY_LOCK_TIMEOUT, function () use ($nodeId, $node) {
+			$lock = $this->lockService->getLockForNodeId($nodeId, $node->getNode());
 
 			if ($lock === false) {
 				return null;
@@ -142,8 +142,8 @@ class LockPlugin extends SabreLockPlugin {
 			return $lock->getTimeout();
 		});
 
-		$propFind->handle(Application::DAV_PROPERTY_LOCK_OWNER_DISPLAYNAME, function () use ($nodeId) {
-			$lock = $this->lockService->getLockForNodeId($nodeId);
+		$propFind->handle(Application::DAV_PROPERTY_LOCK_OWNER_DISPLAYNAME, function () use ($nodeId, $node) {
+			$lock = $this->lockService->getLockForNodeId($nodeId, $node->getNode());
 
 			if ($lock === false) {
 				return null;
@@ -154,8 +154,8 @@ class LockPlugin extends SabreLockPlugin {
 			return $lock->getDisplayName();
 		});
 
-		$propFind->handle(Application::DAV_PROPERTY_LOCK_OWNER_TYPE, function () use ($nodeId) {
-			$lock = $this->lockService->getLockForNodeId($nodeId);
+		$propFind->handle(Application::DAV_PROPERTY_LOCK_OWNER_TYPE, function () use ($nodeId, $node) {
+			$lock = $this->lockService->getLockForNodeId($nodeId, $node->getNode());
 
 			if ($lock === false) {
 				return null;
@@ -164,8 +164,8 @@ class LockPlugin extends SabreLockPlugin {
 			return $lock->getType();
 		});
 
-		$propFind->handle(Application::DAV_PROPERTY_LOCK_EDITOR, function () use ($nodeId) {
-			$lock = $this->lockService->getLockForNodeId($nodeId);
+		$propFind->handle(Application::DAV_PROPERTY_LOCK_EDITOR, function () use ($nodeId, $node) {
+			$lock = $this->lockService->getLockForNodeId($nodeId, $node->getNode());
 			if ($lock === false || $lock->getType() !== ILock::TYPE_APP) {
 				return null;
 			}
@@ -173,8 +173,8 @@ class LockPlugin extends SabreLockPlugin {
 			return $lock->getOwner();
 		});
 
-		$propFind->handle(Application::DAV_PROPERTY_LOCK_TOKEN, function () use ($nodeId) {
-			$lock = $this->lockService->getLockForNodeId($nodeId);
+		$propFind->handle(Application::DAV_PROPERTY_LOCK_TOKEN, function () use ($nodeId, $node) {
+			$lock = $this->lockService->getLockForNodeId($nodeId, $node->getNode());
 			if ($lock === false) {
 				return null;
 			}

--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -26,6 +26,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Lock\ILock;
 use OCP\Files\Lock\LockContext;
 use OCP\Files\Lock\OwnerLockedException;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -88,7 +89,7 @@ class LockService {
 	 *
 	 * @return FileLock|bool
 	 */
-	public function getLockForNodeId(int $nodeId) {
+	public function getLockForNodeId(int $nodeId, ?Node $node = null) {
 		if (array_key_exists($nodeId, $this->lockCache) && $this->lockCache[$nodeId] !== null) {
 			return $this->lockCache[$nodeId];
 		}
@@ -96,7 +97,7 @@ class LockService {
 		try {
 			$this->lockCache[$nodeId] = $this->getLockFromFileId($nodeId);
 		} catch (LockNotFoundException) {
-			$remoteLock = $this->getRemoteLockFromDav($nodeId);
+			$remoteLock = $this->getRemoteLockFromDav($nodeId, $node);
 			$this->lockCache[$nodeId] = $remoteLock ?: false;
 		}
 
@@ -399,15 +400,17 @@ class LockService {
 		$this->locksRequest->removeIds($ids);
 	}
 
-	public function getRemoteLockFromDav(int $nodeId): ?FileLock {
+	public function getRemoteLockFromDav(int $nodeId, ?Node $node = null): ?FileLock {
 		try {
 			$user = $this->userSession->getUser();
 			if (!$user) {
 				return null;
 			}
 
-			$userFolder = $this->rootFolder->getUserFolder($user->getUID());
-			$node = $userFolder->getFirstNodeById($nodeId);
+			if (!$node) {
+				$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+				$node = $userFolder->getFirstNodeById($nodeId);
+			}
 			if (empty($node)) {
 				return null;
 			}


### PR DESCRIPTION
No reason to if we already have the node higher up in the call stack.

Untested