### PR TITLE
fix: replace deprecated getUserSession() with IUserSession

### DIFF
--- a/lib/DAV/LockBackend.php
+++ b/lib/DAV/LockBackend.php
@@ -19,6 +19,7 @@ use OCP\Files\Lock\LockContext;
 use OCP\Files\Lock\OwnerLockedException;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\IUserSession;
 use Sabre\DAV\Locks\Backend\BackendInterface;
 use Sabre\DAV\Locks\LockInfo;
 
@@ -27,6 +28,7 @@ class LockBackend implements BackendInterface {
 		private FileService $fileService,
 		private LockService $lockService,
 		private bool $absolute,
+		private IUserSession $userSession,
 	) {
 	}
 
@@ -43,7 +45,7 @@ class LockBackend implements BackendInterface {
 			$file = $this->getFileFromUri($uri);
 			$lock = $this->lockService->getLockFromFileId($file->getId());
 
-			if ($lock->getType() === ILock::TYPE_USER && $lock->getOwner() === \OC::$server->getUserSession()->getUser()->getUID()) {
+			if ($lock->getType() === ILock::TYPE_USER && $lock->getOwner() === $this->userSession->getUser()?->getUID()) {
 				return [];
 			}
 
@@ -72,7 +74,13 @@ class LockBackend implements BackendInterface {
 				ILock::TYPE_TOKEN,
 				$lockInfo->token
 			));
-			$lock->setUserId(\OC::$server->getUserSession()->getUser()->getUID());
+
+			$user = $this->userSession->getUser();
+			if ($user === null) {
+				return false;
+			}
+
+			$lock->setUserId($user->getUID());
 			$lock->setTimeout($lockInfo->timeout ?? 0);
 			$lock->setToken($lockInfo->token);
 			$lock->setDisplayName($lockInfo->owner);

--- a/lib/DAV/LockPlugin.php
+++ b/lib/DAV/LockPlugin.php
@@ -62,7 +62,7 @@ class LockPlugin extends SabreLockPlugin {
 				$absolute = true;
 				break;
 		}
-		$this->locksBackend = new LockBackend($this->fileService, $this->lockService, $absolute);
+		$this->locksBackend = new LockBackend($this->fileService, $this->lockService, $absolute, $this->userSession);
 		$server->on('propFind', [$this, 'customProperties']);
 		parent::initialize($server);
 	}


### PR DESCRIPTION
`OC\Server::getUserSession()` was deprecated and has been removed, DAV `LOCK` and `UNLOCK` requests were failing with a fatal error as a result.

Replace the removed method with  `IUserSession`.