### PR TITLE
ci: align commit message of asset build

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -81,5 +81,5 @@ jobs:
         if: steps.changes.outputs.CHANGED != ''
         run: |
           git add --force js/ css/
-          git commit --signoff -m 'chore(assets): recompile assets'
+          git commit --signoff -m 'build(assets): recompile assets'
           git push origin ${{ github.head_ref }}


### PR DESCRIPTION
Missed to update this one, so this check at https://github.com/nextcloud/files_lock/blob/73842caff923d84539abfb542b2afee41b829097/.github/workflows/update-node-dist.yml#L58 does not match