### PR TITLE
[stable33] docs: inform about bundling as of NC 34

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,6 +11,8 @@
 
 Allow your users to temporary lock their files to avoid conflicts while working on shared files.
 
+ℹ️ As of Nextcloud 34 this app is bundled with Nextcloud Hub and hence not released through the appstore anymore.
+
 ]]>
 	</description>
 	<version>33.0.2</version>


### PR DESCRIPTION
Opening it against stable33 as I believe this one will be picked up from the appstore upon the next release (but I am not entirely sure tbh).