### PR TITLE
Fix/infinite lock timeout sentinel

### DIFF
--- a/lib/DAV/LockPlugin.php
+++ b/lib/DAV/LockPlugin.php
@@ -139,7 +139,7 @@ class LockPlugin extends SabreLockPlugin {
 				return null;
 			}
 
-			return $lock->getTimeout();
+			return $lock->getETA() === FileLock::ETA_INFINITE ? null : $lock->getTimeout();
 		});
 
 		$propFind->handle(Application::DAV_PROPERTY_LOCK_OWNER_DISPLAYNAME, function () use ($nodeId, $node) {
@@ -278,7 +278,7 @@ class LockPlugin extends SabreLockPlugin {
 			Application::DAV_PROPERTY_LOCK_OWNER_DISPLAYNAME => $lock ? $lock->getDisplayName() : null,
 			Application::DAV_PROPERTY_LOCK_EDITOR => $lock ? $lock->getOwner() : null,
 			Application::DAV_PROPERTY_LOCK_TIME => $lock ? $lock->getCreatedAt() : null,
-			Application::DAV_PROPERTY_LOCK_TIMEOUT => $lock ? $lock->getTimeout() : null,
+			Application::DAV_PROPERTY_LOCK_TIMEOUT => $lock && $lock->getETA() !== FileLock::ETA_INFINITE ? $lock->getTimeout() : null,
 			Application::DAV_PROPERTY_LOCK_TOKEN => $lock ? $lock->getToken() : null,
 		];
 	}

--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -388,6 +388,21 @@ class LockFeatureTest extends TestCase {
 	}
 
 	/**
+	 * Default config (LOCK_TIMEOUT = -1) must produce ETA_INFINITE, not a negative timestamp.
+	 * Regression: getTimeout() returned -60 which clients interpreted as a past expiry.
+	 */
+	public function testDefaultInfiniteTimeoutProducesEtaInfinite() {
+		\OCP\Server::get(IConfig::class)->setAppValue(Application::APP_ID, ConfigService::LOCK_TIMEOUT, '-1');
+
+		$file = $this->loginAndGetUserFolder(self::TEST_USER1)->newFile('test-file', 'AAA');
+		$this->lockManager->lock(new LockContext($file, ILock::TYPE_USER, self::TEST_USER1));
+		$locks = $this->lockManager->getLocks($file->getId());
+
+		$this->assertCount(1, $locks);
+		$this->assertEquals(FileLock::ETA_INFINITE, $locks[0]->getEta());
+	}
+
+	/**
 	 * Regression test for https://github.com/nextcloud/files_lock/issues/130
 	 */
 	public function testExtendInfiniteLock() {


### PR DESCRIPTION
  ### Problem

When a file is locked with no expiry (the default config),  the timeout is `-60` seconds internally and sent that raw value to clients via the WebDAV `nc:lock-timeout` property.

Clients (Android, desktop) interpreted `-60` as a timestamp offset, showing **"Expires: 1 minute ago"** — making it look like a broken or expired lock.

  ### Fix
Before sending `nc:lock-timeout` over WebDAV, check whether the lock is infinite. If it is, send `null` (omit the property) instead of `-60`. Clients receiving no timeout value correctly show the lock as permanent with no expiry.

This issue is compounded a bit by notify_push and the files list not showing the correct state. So EO locks, and then might not update the files list, so if you try to lock within 20 seconds or so, it will fail and error. This fix is to get the lock updated as per the actual lock state. I need to investigate a bit more regarding EO, hence the draft state.