### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ Allow your users to temporary lock their files to avoid conflicts while working 
 ]]>
 	</description>
 	<version>35.0.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Maxence Lange</author>
 	<namespace>FilesLock</namespace>
 	<types>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "nextcloud/files_lock",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"require-dev": {
 		"phpunit/phpunit": "^9.5",
 		"nextcloud/coding-standard": "^1.2"


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
