### PR TITLE
ci(dependabot): add composer updates for stable branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,3 +86,60 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
+
+  # Main stable34 composer
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "03:00"
+      timezone: Europe/Paris
+    cooldown:
+      default-days: 10
+    target-branch: stable34
+    labels:
+      - "3. to review"
+      - "dependencies"
+    ignore:
+      # do not do breaking changes on stable branches
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # Main stable33 composer
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "03:00"
+      timezone: Europe/Paris
+    cooldown:
+      default-days: 10
+    target-branch: stable33
+    labels:
+      - "3. to review"
+      - "dependencies"
+    ignore:
+      # do not do breaking changes on stable branches
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # Main stable32 composer
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "03:00"
+      timezone: Europe/Paris
+    cooldown:
+      default-days: 10
+    target-branch: stable32
+    labels:
+      - "3. to review"
+      - "dependencies"
+    ignore:
+      # do not do breaking changes on stable branches
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
composer dependencies were only updated on main while npm already covered stable32-34. Add patch-only composer update entries for the maintained stable branches so both ecosystems stay covered everywhere.

Beware: files_lock's root composer.json has no third-party production requires (the composer surface is dev tooling), so these stable entries are mostly future-proofing

Assisted-by: Claude Code:claude-fable-5



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
