### PR TITLE
fix(webdav): align lock editor property responses

### DIFF
--- a/lib/DAV/LockPlugin.php
+++ b/lib/DAV/LockPlugin.php
@@ -277,7 +277,9 @@ class LockPlugin extends SabreLockPlugin {
 			Application::DAV_PROPERTY_LOCK_OWNER_TYPE => $lock ? $lock->getType() : null,
 			Application::DAV_PROPERTY_LOCK_OWNER => $lock ? $lock->getOwner() : null,
 			Application::DAV_PROPERTY_LOCK_OWNER_DISPLAYNAME => $lock ? $lock->getDisplayName() : null,
-			Application::DAV_PROPERTY_LOCK_EDITOR => $lock ? $lock->getOwner() : null,
+			Application::DAV_PROPERTY_LOCK_EDITOR => $lock?->getType() === ILock::TYPE_APP
+				? $lock->getOwner()
+				: null,
 			Application::DAV_PROPERTY_LOCK_TIME => $lock ? $lock->getCreatedAt() : null,
 			Application::DAV_PROPERTY_LOCK_TIMEOUT => $lock ? $lock->getTimeout() : null,
 			Application::DAV_PROPERTY_LOCK_TOKEN => $lock ? $lock->getToken() : null,


### PR DESCRIPTION
## Summary

Align the custom `X-User-Lock` response with `PROPFIND` behavior for the `lock-owner-editor` property.

The response now returns the editor/app ID only for app-owned locks. User-owned and token-owned locks return an empty value.

Noticed while working on the docs update in #1198.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
