### PR TITLE
test(lock): access shared file as recipient in app lock test

### DIFF
--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -294,11 +294,13 @@ class LockFeatureTest extends TestCase {
 			self::assertEquals('EEE', $file->getContent());
 		});
 
-		$this->loginAndGetUserFolder(self::TEST_USER2);
-		$this->lockManager->runInScope($scope, function () use ($file): void {
+		/** @var File $sharedFile */
+		$sharedFile = $this->loginAndGetUserFolder(self::TEST_USER2)
+			->get('test-file2');
+		$this->lockManager->runInScope($scope, function () use ($sharedFile): void {
 			self::assertEquals('collaborative_app', $this->lockManager->getLockInScope()->getOwner());
-			$file->putContent('FFF');
-			self::assertEquals('FFF', $file->getContent());
+			$sharedFile->putContent('FFF');
+			self::assertEquals('FFF', $sharedFile->getContent());
 		});
 	}
 


### PR DESCRIPTION
Previously `testLockApp()` was not actually testing the second user’s view of the share. The test logged in as `user2`, but the callback used the original `$file` object obtained from `user1`’s folder.

Now (re-)fetches the shared file from User 2's filesystem view after switching users and verifies the authorized write through the recipient's share mount rather than the original owner's `File` object.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
