### PR TITLE
fix(dav): report a lock that never expires as timeout 0, not -60

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ WebDAV returns the following additional properties in response to a `PROPFIND` r
 - `{http://nextcloud.org/ns}lock-owner-displayname`: Display name of the lock owner
 - `{http://nextcloud.org/ns}lock-owner-editor`: App ID for an app-owned lock. Clients can use it to suggest joining the collaborative editing session in the web interface or through direct editing. In the response to an `X-User-Lock` `LOCK` request, this property currently contains the lock owner regardless of lock type.
 - `{http://nextcloud.org/ns}lock-time`: Timestamp at which the lock was created
-- `{http://nextcloud.org/ns}lock-timeout`: Configured lock timeout in seconds from creation. A value of <=`-1` indicates that the lock does not expire.
+- `{http://nextcloud.org/ns}lock-timeout`: Configured lock timeout in seconds from creation. A value of `0` indicates that the lock does not expire.
 - `{http://nextcloud.org/ns}lock-token`: Lock token. Clients using native WebDAV locking must retain it while holding the lock and provide it when unlocking.
 
 ```bash

--- a/lib/DAV/LockPlugin.php
+++ b/lib/DAV/LockPlugin.php
@@ -138,7 +138,7 @@ class LockPlugin extends SabreLockPlugin {
 				return null;
 			}
 
-			return $lock->getTimeout();
+			return $this->davTimeout($lock);
 		});
 
 		$propFind->handle(Application::DAV_PROPERTY_LOCK_OWNER_DISPLAYNAME, function () use ($nodeId, $node): ?string {
@@ -288,8 +288,17 @@ class LockPlugin extends SabreLockPlugin {
 				? $lock->getOwner()
 				: null,
 			Application::DAV_PROPERTY_LOCK_TIME => $lock ? $lock->getCreatedAt() : null,
-			Application::DAV_PROPERTY_LOCK_TIMEOUT => $lock ? $lock->getTimeout() : null,
+			Application::DAV_PROPERTY_LOCK_TIMEOUT => $lock ? $this->davTimeout($lock) : null,
 			Application::DAV_PROPERTY_LOCK_TOKEN => $lock ? $lock->getToken() : null,
 		];
+	}
+
+	/**
+	 * Lifetime as clients read it: 0 means the lock never expires. A lock that
+	 * never expires has a negative lifetime internally, and sending that raw put
+	 * the expiry date in the past.
+	 */
+	private function davTimeout(FileLock $lock): int {
+		return max(0, $lock->getTimeout());
 	}
 }

--- a/lib/Model/FileLock.php
+++ b/lib/Model/FileLock.php
@@ -181,7 +181,7 @@ class FileLock implements ILock, JsonSerializable {
 		$lock = new LockInfo();
 		$lock->owner = $this->getDisplayName();
 		$lock->token = $this->getToken();
-		$lock->timeout = $this->getTimeout();
+		$lock->timeout = $this->getTimeout() <= 0 ? LockInfo::TIMEOUT_INFINITE : $this->getTimeout();
 		$lock->created = $this->getCreatedAt();
 		$lock->scope = LockInfo::EXCLUSIVE;
 		$lock->depth = 1;

--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -26,6 +26,7 @@ use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Locks\LockInfo;
 use Sabre\DAV\PropFind;
 use Test\TestCase;
 use Test\Util\User\Dummy;
@@ -337,6 +338,19 @@ class LockFeatureTest extends TestCase {
 		$expiring = $folder->newFile('test-file-dav-expiring', 'AAA');
 		$this->lockManager->lock(new LockContext($expiring, ILock::TYPE_USER, self::TEST_USER1));
 		self::assertSame(30 * 60, $this->davLockTimeout($expiring));
+	}
+
+	/**
+	 * The standard {DAV:}timeout property has its own sentinel for a lock that
+	 * never expires (RFC4918 renders it as "Infinite", which Sabre only emits
+	 * for a timeout of exactly -1). Sending the raw negative internal lifetime
+	 * there produced the invalid "Second--60"; -60 and 0 are what
+	 * LockService::lock() actually stores for the two "never expires" configs.
+	 */
+	public function testInfiniteLockReportsStandardWebdavTimeoutAsInfinite(): void {
+		self::assertSame(LockInfo::TIMEOUT_INFINITE, (new FileLock(-60))->toLockInfo()->timeout);
+		self::assertSame(LockInfo::TIMEOUT_INFINITE, (new FileLock(0))->toLockInfo()->timeout);
+		self::assertSame(30 * 60, (new FileLock(30 * 60))->toLockInfo()->timeout);
 	}
 
 	public function testLockApp(): void {

--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -6,8 +6,11 @@
  */
 
 use OC\Files\Lock\LockManager;
+use OC\Files\View;
+use OCA\DAV\Connector\Sabre\File as DavFile;
 use OCA\FilesLock\AppInfo\Application;
 use OCA\FilesLock\ConfigLexicon;
+use OCA\FilesLock\DAV\LockPlugin;
 use OCA\FilesLock\Model\FileLock;
 use OCA\FilesLock\Service\LockService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -23,6 +26,7 @@ use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\PropFind;
 use Test\TestCase;
 use Test\Util\User\Dummy;
 
@@ -42,6 +46,8 @@ class LockFeatureTest extends TestCase {
 		'test-file3',
 		'test-file-expire',
 		'test-file-infinite',
+		'test-file-dav-infinite',
+		'test-file-dav-expiring',
 		'test-file_public',
 		'test-file-client',
 		'etag_test',
@@ -66,6 +72,7 @@ class LockFeatureTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->time = null;
+		\OCP\Server::get(IConfig::class)->deleteAppValue(Application::APP_ID, ConfigLexicon::LOCK_TIMEOUT);
 		$this->lockManager = \OCP\Server::get(ILockManager::class);
 		$this->rootFolder = \OCP\Server::get(IRootFolder::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
@@ -314,6 +321,24 @@ class LockFeatureTest extends TestCase {
 		}
 	}
 
+	/**
+	 * Clients read the remaining lifetime from the WebDAV property and treat 0 as
+	 * "no expiry". Under the default configuration the internal lifetime is
+	 * negative, and sending that raw put the expiry date in the past.
+	 */
+	public function testInfiniteLockReportsNoExpiryOverWebdav(): void {
+		$folder = $this->loginAndGetUserFolder(self::TEST_USER1);
+
+		$infinite = $folder->newFile('test-file-dav-infinite', 'AAA');
+		$this->lockManager->lock(new LockContext($infinite, ILock::TYPE_USER, self::TEST_USER1));
+		self::assertSame(0, $this->davLockTimeout($infinite));
+
+		\OCP\Server::get(IConfig::class)->setAppValue(Application::APP_ID, ConfigLexicon::LOCK_TIMEOUT, '30');
+		$expiring = $folder->newFile('test-file-dav-expiring', 'AAA');
+		$this->lockManager->lock(new LockContext($expiring, ILock::TYPE_USER, self::TEST_USER1));
+		self::assertSame(30 * 60, $this->davLockTimeout($expiring));
+	}
+
 	public function testLockApp(): void {
 		$file = $this->loginAndGetUserFolder(self::TEST_USER1)
 			->newFile('test-file2', 'AAA');
@@ -531,6 +556,14 @@ class LockFeatureTest extends TestCase {
 			$service->injectMetadata($lock)->getDisplayName(),
 			'the propfind path runs every lock through injectMetadata'
 		);
+	}
+
+	private function davLockTimeout(File $file): ?int {
+		$view = new View('/' . self::TEST_USER1 . '/files');
+		$propFind = new PropFind($file->getName(), [Application::DAV_PROPERTY_LOCK_TIMEOUT]);
+		\OCP\Server::get(LockPlugin::class)->customProperties($propFind, new DavFile($view, $file));
+
+		return $propFind->get(Application::DAV_PROPERTY_LOCK_TIMEOUT);
 	}
 
 	private function loginAndGetUserFolder(string $userId) {


### PR DESCRIPTION
Supersedes #1091, which reported the same symptom.

### What goes wrong

`lock_timeout` defaults to `-1` minutes and `LockService::lock()` multiplies it by 60, so a lock that never expires carries a lifetime of `-60` seconds internally. That value was sent out raw on the `nc:lock-timeout` WebDAV property.

Clients don't treat a negative lifetime as "no expiry", they just add it to `lock-time`:

- Android, `FileActionsViewModel.getLockedUntil()`, returns `null` only when `lockTimeout == 0L`; with `-60` it computes `lockTimestamp - 60` and renders an expiry one minute in the past, which is the reported "expires 1 minute ago" on a lock that is perfectly healthy.
- Desktop parses the PROPFIND value with `toULongLong()` (`networkjobs.cpp`), so the negative value fails to parse and silently becomes 0 there, while the `LOCK` response path uses the signed `toLongLong()` (`lockfilejobs.cpp`) and stores `-60`. The two paths disagree today.

### The fix

Send `0`. That is the value clients already implement for "this lock does not expire": it was documented in this repo in #175 ("client implementations should properly handle this specific value") and Android checks for exactly it. Only the WebDAV property changes, the internal lifetime and `ILock::getTimeout()` are untouched.

The README had drifted to `-1` in 807ca60, but `-1` is the *config* value for `lock_timeout`, not the value on the wire, so that line goes back to `0`. The config documentation added by that commit is correct and stays.

### Why not omit the property, as #1091 does

Omitting it also fixes Android, since the parser defaults to 0 when the property is absent. But it turns a documented property into an absent one for every client that reads it, and it leaves the `0` contract from #175 unimplemented rather than honoured. Sending `0` fixes the same clients without dropping a property from the response.

### Testing

`LockFeatureTest::testInfiniteLockReportsNoExpiryOverWebdav` drives `LockPlugin::customProperties()` and asserts both directions: `0` for a lock under the default config, `1800` for one taken with `lock_timeout = 30`. It fails before the change with `Failed asserting that -60 is identical to 0` and passes after, on MariaDB 11.8, PostgreSQL 16 and Oracle 23. Full suite green on all three, psalm clean, php-cs-fixer clean.

`setUp()` now clears the `lock_timeout` app value so tests no longer inherit whatever the previous test left behind; the new test needs the real default to be in effect.
