### PR TITLE
fix(deps): require PHP 8.2 to match nextcloud/ocp stable33

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.1"
+			"php": "8.2"
 		}
 	},
 	"require": {
-		"php": "^8.1"
+		"php": "^8.2"
 	},
 	"scripts": {
 		"lint": "find . -name \\*.php -not -path './vendor/*' -print0 | xargs -0 -n1 php -l",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72c8c58fcd2c1ac52c9b10857db18503",
+    "content-hash": "e3f54b0abb1947e5e8ea0efa6f8c2a6b",
     "packages": [],
     "packages-dev": [
         {
@@ -240,16 +240,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6f53a7ad7eda8c00f335b38e392cb76494d82422"
+                "reference": "43727c5a1a74040945700b4c34056f7729fe87f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f53a7ad7eda8c00f335b38e392cb76494d82422",
-                "reference": "6f53a7ad7eda8c00f335b38e392cb76494d82422",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/43727c5a1a74040945700b4c34056f7729fe87f3",
+                "reference": "43727c5a1a74040945700b4c34056f7729fe87f3",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5",
+                "php": "~8.2 || ~8.3 || ~8.4 || ~8.5",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
@@ -280,7 +280,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-05-21T02:07:59+00:00"
+            "time": "2026-09-02T01:51:47+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2674,11 +2674,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
`nextcloud/ocp:dev-stable33` requires PHP `~8.2 || ~8.3 || ~8.4 || ~8.5` since a recent commit, but `composer.json` here was still pinned to `^8.1` (`config.platform.php` included), so the weekly `Update nextcloud/ocp` workflow can no longer resolve dependencies on this branch.

Bumps the platform/require constraint to `^8.2`, matching what the workflow already installs (`Set up php8.2`), and regenerates `composer.lock` accordingly.

Fixes #1208, #1217, #1229, #1236, #1245, #1252, #1264