### PR TITLE
fix(lock): stop overwriting a lock's creation time with the real clock

### DIFF
--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -160,7 +160,6 @@ class LockService {
 		} catch (LockNotFoundException) {
 			$lock = FileLock::fromLockScope($lockScope, $timeout);
 			$this->generateToken($lock);
-			$lock->setCreation(time());
 			$this->logger->notice('locking file', ['fileLock' => $lock]);
 			$this->injectMetadata($lock);
 			$this->locksRequest->save($lock);

--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -47,6 +47,7 @@ class LockFeatureTest extends TestCase {
 		'test-file3',
 		'test-file-expire',
 		'test-file-infinite',
+		'test-file-creation-clock',
 		'test-file-dav-infinite',
 		'test-file-dav-expiring',
 		'test-file_public',
@@ -265,6 +266,17 @@ class LockFeatureTest extends TestCase {
 		$service->removeLocks([$lock]);
 
 		self::assertCount(0, $this->lockManager->getLocks($file->getId()));
+	}
+
+	/**
+	 * Reading the wall clock here instead would race the clock tests mock in.
+	 */
+	public function testLockCreationUsesTheInjectedClock(): void {
+		$this->time = strtotime('2000-01-01T00:00:00+00:00');
+		$file = $this->loginAndGetUserFolder(self::TEST_USER1)->newFile('test-file-creation-clock', 'AAA');
+		$lock = $this->lockManager->lock(new LockContext($file, ILock::TYPE_USER, self::TEST_USER1));
+
+		self::assertSame($this->time, $lock->getCreatedAt());
 	}
 
 	// Use expired locks to model the cron cleanup workflow:


### PR DESCRIPTION
LockService::lock() called setCreation(time()) right after building the FileLock, overwriting the creation timestamp FileLock's own constructor had already set correctly via the injected ITimeFactory. Redundant under normal operation, but it bypasses whatever clock a test mocks in.

This is what made `testRemoveDeprecatedLocks` (added in #1205) flake intermittently in CI on MySQL and Oracle: that test freezes the mocked clock and advances it 1 second past its 30-minute cutoff, but the lock's actual creation came from the real clock a few milliseconds later. Whenever wall-clock execution crossed a second boundary in between, creation landed exactly on the cutoff instead of before it, and the strict `<` comparison in `getLocksOlderThan()` excluded the lock.

### Testing

Reproduced the race directly: looped the lock/check cycle against real PHP 8.5 + MySQL 8.4 until it failed, confirming creation and cutoff land on the same second. Added `testLockCreationUsesTheInjectedClock`, a deterministic (non-looping) regression test that freezes the clock to an obviously-fake value and asserts the lock's creation matches it exactly — fails red without the fix.

Verified: full suite green on MariaDB, PostgreSQL, and 20+ consecutive runs against PHP 8.5 + MySQL 8.4 (previously failing ~1 in 10-15 runs there). php-cs-fixer and psalm clean.