### PR TITLE
fix(lock): move the etag when a lock is dropped for having expired

### DIFF
--- a/lib/Service/LockService.php
+++ b/lib/Service/LockService.php
@@ -120,7 +120,7 @@ class LockService {
 		$expiredLocks = [];
 		foreach ($newLocks as $lock) {
 			if ($lock->getETA() === 0) {
-				$expiredLocks[] = $lock->getId();
+				$expiredLocks[] = $lock;
 				$locks[$lock->getFileId()] = false;
 				$this->lockCache[$lock->getFileId()] = false;
 			} else {
@@ -129,9 +129,7 @@ class LockService {
 			}
 		}
 
-		if (count($expiredLocks) > 0) {
-			$this->locksRequest->removeIds($expiredLocks);
-		}
+		$this->removeLocks($expiredLocks);
 
 		return $locks;
 	}
@@ -163,7 +161,7 @@ class LockService {
 			$this->logger->notice('locking file', ['fileLock' => $lock]);
 			$this->injectMetadata($lock);
 			$this->locksRequest->save($lock);
-			$this->propagateEtag($lockScope);
+			$this->propagateEtag($lockScope->getNode());
 			return $lock;
 		}
 	}
@@ -194,7 +192,7 @@ class LockService {
 
 		$this->locksRequest->delete($known);
 		$this->lockCache[$lock->getNode()->getId()] = false;
-		$this->propagateEtag($lock);
+		$this->propagateEtag($lock->getNode());
 		$this->injectMetadata($known);
 		return $known;
 	}
@@ -278,7 +276,6 @@ class LockService {
 			$lockType,
 			$userId,
 		);
-		$this->propagateEtag($lock);
 		return $this->unlock($lock, $force);
 	}
 
@@ -309,7 +306,7 @@ class LockService {
 	public function getLockFromFileId(int $fileId): FileLock {
 		$lock = $this->locksRequest->getFromFileId($fileId);
 		if ($lock->getETA() === 0) {
-			$this->locksRequest->delete($lock);
+			$this->removeLocks([$lock]);
 			throw new LockNotFoundException('lock is ignored and deleted as being too old.');
 		}
 
@@ -377,6 +374,9 @@ class LockService {
 		$this->logger->notice('removing locks', ['ids' => $ids]);
 
 		$this->locksRequest->removeIds($ids);
+		foreach ($locks as $lock) {
+			$this->propagateEtagForLock($lock);
+		}
 	}
 
 	public function getRemoteLockFromDav(int $nodeId, ?Node $node = null): ?FileLock {
@@ -436,8 +436,31 @@ class LockService {
 		}
 	}
 
-	private function propagateEtag(LockContext $lockContext): void {
-		$node = $lockContext->getNode();
+	/**
+	 * A lock that goes away on its own has to move the etag the way an explicit
+	 * unlock does, because sync clients only re-read the lock properties of a
+	 * file whose etag changed.
+	 *
+	 * Runs without a session, for the cleanup job: the owner's folder gives a
+	 * scoped lookup for a user lock, and the root falls back on the mount cache
+	 * for an app owned lock, whose owner is an app id rather than an account.
+	 */
+	private function propagateEtagForLock(FileLock $lock): void {
+		try {
+			$node = null;
+			if ($this->userManager->userExists($lock->getOwner())) {
+				$node = $this->rootFolder->getUserFolder($lock->getOwner())->getFirstNodeById($lock->getFileId());
+			}
+			$node ??= $this->rootFolder->getFirstNodeById($lock->getFileId());
+			if ($node !== null) {
+				$this->propagateEtag($node);
+			}
+		} catch (Exception $e) {
+			$this->logger->warning('Failed to propagate the etag of an expired lock', ['exception' => $e]);
+		}
+	}
+
+	private function propagateEtag(Node $node): void {
 		$node->getStorage()->getCache()->update($node->getId(), [
 			'etag' => uniqid(),
 		]);

--- a/tests/Feature/LockFeatureTest.php
+++ b/tests/Feature/LockFeatureTest.php
@@ -11,6 +11,7 @@ use OCA\DAV\Connector\Sabre\File as DavFile;
 use OCA\FilesLock\AppInfo\Application;
 use OCA\FilesLock\ConfigLexicon;
 use OCA\FilesLock\DAV\LockPlugin;
+use OCA\FilesLock\Exceptions\LockNotFoundException;
 use OCA\FilesLock\Model\FileLock;
 use OCA\FilesLock\Service\LockService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -24,6 +25,7 @@ use OCP\IUserManager;
 use OCP\Lock\ManuallyLockedException;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Locks\LockInfo;
@@ -187,6 +189,80 @@ class LockFeatureTest extends TestCase {
 
 		self::assertNotEquals($oldRootEtag, $newRootEtag);
 		self::assertNotEquals($oldEtag, $file->getEtag());
+	}
+
+	/**
+	 * Every way a lock can be dropped for having expired.
+	 *
+	 * @return array<string, list<\Closure(LockService, int): void>>
+	 */
+	public static function expiryTriggers(): array {
+		return [
+			'the cleanup job' => [static function (LockService $service, int $fileId): void {
+				$service->removeLocks($service->getDeprecatedLocks());
+			}],
+			'a single read' => [static function (LockService $service, int $fileId): void {
+				try {
+					$service->getLockFromFileId($fileId);
+				} catch (LockNotFoundException) {
+				}
+			}],
+			'the bulk read behind a directory PROPFIND' => [static function (LockService $service, int $fileId): void {
+				$service->getLockForNodeIds([$fileId]);
+			}],
+		];
+	}
+
+	/**
+	 * A lock that expires has to move the etag the way an explicit unlock does.
+	 * Sync clients only re-read a file's lock properties when its etag changed,
+	 * so without this the desktop keeps showing an expired lock and keeps the
+	 * local file read-only until someone locks and unlocks it by hand.
+	 *
+	 * @param \Closure(LockService, int): void $expire
+	 */
+	#[DataProvider('expiryTriggers')]
+	public function testExpiredLockPropagatesEtag(\Closure $expire): void {
+		\OCP\Server::get(IConfig::class)->setAppValue(Application::APP_ID, ConfigLexicon::LOCK_TIMEOUT, 30);
+		$file = $this->loginAndGetUserFolder(self::TEST_USER1)->newFile('etag_test', 'etag_test');
+		$this->lockManager->lock(new LockContext($file, ILock::TYPE_USER, self::TEST_USER1));
+
+		$file = $this->loginAndGetUserFolder(self::TEST_USER1)->get('etag_test');
+		$fileId = $file->getId();
+		$lockedEtag = $file->getEtag();
+		$lockedRootEtag = $this->loginAndGetUserFolder(self::TEST_USER1)->getEtag();
+
+		$this->toTheFuture(30 * 60 + 1);
+		$service = \OCP\Server::get(LockService::class);
+		$service->clearCache();
+		$expire($service, $fileId);
+
+		$file = $this->loginAndGetUserFolder(self::TEST_USER1)->get('etag_test');
+		$newRootEtag = $this->loginAndGetUserFolder(self::TEST_USER1)->getEtag();
+
+		self::assertNotEquals($lockedEtag, $file->getEtag(), 'the file etag must change when the lock expires');
+		self::assertNotEquals($lockedRootEtag, $newRootEtag, 'and the change must propagate up the tree');
+	}
+
+	/**
+	 * An app lock is owned by an app id, not by an account, so the file cannot be
+	 * resolved through an owner's folder and has to come from the mount cache.
+	 */
+	public function testExpiredAppLockPropagatesEtag(): void {
+		\OCP\Server::get(IConfig::class)->setAppValue(Application::APP_ID, ConfigLexicon::LOCK_TIMEOUT, 30);
+		$file = $this->loginAndGetUserFolder(self::TEST_USER1)->newFile('etag_test', 'etag_test');
+		$this->lockManager->lock(new LockContext($file, ILock::TYPE_APP, 'collaborative_app'));
+
+		$file = $this->loginAndGetUserFolder(self::TEST_USER1)->get('etag_test');
+		$lockedEtag = $file->getEtag();
+
+		$this->toTheFuture(30 * 60 + 1);
+		$service = \OCP\Server::get(LockService::class);
+		$service->clearCache();
+		$service->removeLocks($service->getDeprecatedLocks());
+
+		$file = $this->loginAndGetUserFolder(self::TEST_USER1)->get('etag_test');
+		self::assertNotEquals($lockedEtag, $file->getEtag(), 'an app owned lock has no account to resolve through');
 	}
 
 	public function testUnlockEtagShare(): void {


### PR DESCRIPTION
Fixes #191
Related to #981

An explicit unlock moves the file's etag, a lock that expires does not, and that difference decides what sync clients see. The desktop only re-reads a file's lock properties when its etag changed, and it short-circuits three times over: an unchanged root etag skips the sync run (`folder.cpp` `etagRetrieved`), an unchanged directory etag sets `ParentNotChanged` so children are never PROPFINDed, and an unchanged file etag yields instruction `NONE`, which the sync engine ignores. Lock state is written back only on `UPDATE_METADATA`. So an expired lock is dropped here and the client is never told.

On Windows the client also sets `FILE_ATTRIBUTE_READONLY` plus a deny ACL, reverted only from inside a propagation job, so the local file stays read-only indefinitely. Both issues report the same self-discovered workaround, locking and unlocking in the web UI, which moves the etag twice and lets the client catch up. #981 confirms both lock tables are empty while the file is still read-only.

#981 is referenced rather than closed on purpose. This removes the server side cause for it, but the client only lifts its local read-only state inside `if (item->_type == ItemTypeVirtualFile)` in `syncengine.cpp`, so a hydrated file gets the notification and stays read-only anyway. That half is nextcloud/desktop#10453. #191 is about the stale lock state itself, which the journal now reconciles for every file.

Covers the three paths that drop an expired lock: the cleanup job, the single read, and the bulk read behind a directory PROPFIND. The file is resolved through the owner's folder first because that is what sets up a filesystem for the job, which runs without a session.

Worth knowing: this does not make the notification channel correct. Faking an etag change is also what produces a conflicted copy when a file is locked while a client has local edits (#553), so the channel misfires in both directions. Giving lock state its own signal is a larger change than this one, and #1230 is a separate matter.

